### PR TITLE
Consolidating tax items to taxes.php

### DIFF
--- a/Taxes.php
+++ b/Taxes.php
@@ -1,4 +1,3 @@
 <option <?php if($item_tax == '0.00'){ echo "selected"; } ?> value="0.00">None</option>
 <option <?php if($item_tax == '0.07'){ echo "selected"; } ?> value="0.07">State Tax 7%</option>
-<option <?php if($item_tax == '0.05'){ echo "selected"; } ?> value="0.05">Sales Tax 5%</option>
-<option <?php if($item_tax == '0.12'){ echo "selected"; } ?> value="0.12">BC Sales Tax 12%</option>
+

--- a/Taxes.php
+++ b/Taxes.php
@@ -1,0 +1,4 @@
+<option <?php if($item_tax == '0.00'){ echo "selected"; } ?> value="0.00">None</option>
+<option <?php if($item_tax == '0.07'){ echo "selected"; } ?> value="0.07">State Tax 7%</option>
+<option <?php if($item_tax == '0.05'){ echo "selected"; } ?> value="0.05">Sales Tax 5%</option>
+<option <?php if($item_tax == '0.12'){ echo "selected"; } ?> value="0.12">BC Sales Tax 12%</option>

--- a/edit_invoice_item_modal.php
+++ b/edit_invoice_item_modal.php
@@ -67,8 +67,7 @@
                 <span class="input-group-text"><i class="fa fa-fw fa-piggy-bank"></i></span>
               </div>
               <select class="form-control select2" name="tax">
-                <option <?php if($item_tax == '0.00'){ echo "selected"; } ?> value="0.00">None</option>
-                <option <?php if($item_tax == '0.07'){ echo "selected"; } ?> value="0.07">State Tax 7%</option>
+                <?php include"taxes.php"; ?>
               </select>
             </div>
           </div>

--- a/edit_quote_item_modal.php
+++ b/edit_quote_item_modal.php
@@ -68,8 +68,7 @@
                 <span class="input-group-text"><i class="fa fa-fw fa-piggy-bank"></i></span>
               </div>
               <select class="form-control select2" name="tax">
-                <option <?php if($item_tax == '0.00'){ echo "selected"; } ?> value="0.00">None</option>
-                <option <?php if($item_tax == '0.07'){ echo "selected"; } ?> value="0.07">State Tax 7%</option>
+                <?php include"taxes.php"; ?>
               </select>
             </div>
           </div>

--- a/edit_recurring_item_modal.php
+++ b/edit_recurring_item_modal.php
@@ -68,8 +68,7 @@
                 <span class="input-group-text"><i class="fa fa-fw fa-piggy-bank"></i></span>
               </div>
               <select class="form-control select2" name="tax">
-                <option <?php if($item_tax == '0.00'){ echo "selected"; } ?> value="0.00">None</option>
-                <option <?php if($item_tax == '0.07'){ echo "selected"; } ?> value="0.07">State Tax 7%</option>
+                <?php include"taxes.php"; ?>
               </select>
             </div>
           </div>

--- a/invoice.php
+++ b/invoice.php
@@ -261,8 +261,7 @@ if(isset($_GET['invoice_id'])){
                   <td><input type="number" step="0.01" class="form-control" style="text-align: right;" name="price" placeholder="Price"></td>
                   <td>
                     <select class="form-control select2" name="tax">
-                      <option <?php if($item_tax == '0.00'){ echo "selected"; } ?> value="0.00">None</option>
-                      <option <?php if($item_tax == '0.07'){ echo "selected"; } ?> value="0.07">State Tax 7%</option>
+                      <?php include"taxes.php"; ?>
                     </select>
                   </td>
                   <td>

--- a/quote.php
+++ b/quote.php
@@ -228,8 +228,7 @@ if(isset($_GET['quote_id'])){
                   <td><input type="number" step="0.01" min="0" class="form-control" style="text-align: right;" name="price" placeholder="Price"></td>
                   <td>
                     <select class="form-control select2" name="tax">
-                      <option value="0.00">None</option>
-                      <option value="0.07">State Tax 7%</option>
+                      <?php include"taxes.php"; ?>
                     </select>
                   </td>
                   <td>

--- a/recurring_invoice.php
+++ b/recurring_invoice.php
@@ -206,8 +206,7 @@ if(isset($_GET['recurring_id'])){
                   <td><input type="number" step="0.01" min="0" class="form-control" style="text-align: right;" name="price" placeholder="Price"></td>
                   <td>
                     <select class="form-control select2" name="tax">
-                      <option <?php if($item_tax == '0.00'){ echo "selected"; } ?> value="0.00">None</option>
-                      <option <?php if($item_tax == '0.07'){ echo "selected"; } ?> value="0.07">State Tax 7%</option>
+                      <?php include"taxes.php"; ?>
                     </select>
                   </td>
                   <td>


### PR DESCRIPTION
These are the changes we did to help consolidate tax items. fixes #127 (At least makes it easier to deal with)

All the tax options have been consolidated into taxes.php, which is now called as a php include wherever the taxes dropdown appeard. Editing items in taxes.php will update the items in the dropdown boxes accordingly.