### PR TITLE
Check that config.php is writable at the start of setup.

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -329,6 +329,7 @@ $currencies_array = array(
 
 if(isset($_POST['add_database'])){
 
+  // Check if database has been setup already. If it has, direct user to edit directly instead.
   if(file_exists('config.php')){
     $_SESSION['alert_message'] = "Database already configured. Any further changes should be made by editing the config.php file.";
     header("Location: setup.php?user");
@@ -951,6 +952,16 @@ if(isset($_POST['add_company_settings'])){
                 <li>Get List of Emails in CSV to export to a mailing list</li>
                 <li>Acquire balance can be useful for customer's to get their balance by phone</li>
               </ul>
+                <?php
+                    // Check that there is access to write config.php
+                    if (!file_put_contents("config.php", "Test")) {
+                        echo "<div class=\"alert alert-danger\" role=\"alert\">Warning: config.php is not writable. Ensure Apache has write access. </div>";
+                    }
+                    else {
+                        // Else, able to write. Tidy up
+                        unlink("config.php");
+                    }
+                ?>
               <center><a href="?database" class="btn btn-primary">Setup <i class="fa fa-fw fa-arrow-alt-circle-right"></i></a></center>
             </div>
           </div>


### PR DESCRIPTION
_My first pull request, relogged, please be gentle._

Whilst setting this up on my Linux VM, I noticed that the setup would just continuously loop. Apache did not have access to write files into my directory (chmod 755, as per general best practice).

I've just added a small check that we can write config.php.
I did see you've got a setup_checks but this doesn't seem to be in use, from what I could see.