### PR TITLE
Add support for storing client certificate public key

### DIFF
--- a/add_certificate_modal.php
+++ b/add_certificate_modal.php
@@ -32,12 +32,12 @@
           </div>
           
           <div class="form-group">
-            <label>Issued By <strong class="text-danger">*</strong></label>
+            <label>Issued By </label>
             <div class="input-group">
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-building"></i></span>
               </div>
-              <input type="text" class="form-control" name="issued_by" placeholder="Issued By" required>
+              <input type="text" class="form-control" name="issued_by" placeholder="Issued By">
             </div>
           </div>
         
@@ -50,6 +50,16 @@
               <input type="date" class="form-control" name="expire"> 
             </div>
           </div>
+
+        <div class="form-group">
+            <label>Public Key </label>
+            <div class="input-group">
+                <div class="input-group-prepend">
+                    <span class="input-group-text"><i class="fa fa-fw fa-key"></i></span>
+                </div>
+                <textarea class="form-control" name="public_key" placeholder="-----BEGIN CERTIFICATE-----"></textarea>
+            </div>
+        </div>
 
         </div>
         <div class="modal-footer bg-white">

--- a/client_certificates.php
+++ b/client_certificates.php
@@ -99,6 +99,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
             $certificate_issued_by = $row['certificate_issued_by'];
             $certificate_expire = $row['certificate_expire'];
             $certificate_updated_at = $row['certificate_updated_at'];
+            $certificate_public_key = $row['certificate_public_key'];
 
           ?>
           <tr>

--- a/db.sql
+++ b/db.sql
@@ -190,6 +190,7 @@ CREATE TABLE `certificates` (
   `certificate_created_at` datetime NOT NULL,
   `certificate_updated_at` datetime DEFAULT NULL,
   `certificate_archived_at` datetime DEFAULT NULL,
+  `certificate_public_key` varchar(1500) NOT NULL,
   `certificate_client_id` int(11) NOT NULL,
   `company_id` int(11) NOT NULL,
   PRIMARY KEY (`certificate_id`)

--- a/edit_certificate_modal.php
+++ b/edit_certificate_modal.php
@@ -32,12 +32,12 @@
           </div>
 
           <div class="form-group">
-            <label>Issued By <strong class="text-danger">*</strong></label>
+            <label>Issued By</label>
             <div class="input-group">
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-building"></i></span>
               </div>
-              <input type="text" class="form-control" name="issued_by" placeholder="Issued By" value="<?php echo $certificate_issued_by; ?>" required>
+              <input type="text" class="form-control" name="issued_by" placeholder="Issued By" value="<?php echo $certificate_issued_by; ?>">
             </div>
           </div>
         
@@ -50,6 +50,16 @@
               <input type="date" class="form-control" name="expire" value="<?php echo $certificate_expire; ?>"> 
             </div>
           </div>
+
+        <div class="form-group">
+            <label>Public Key </label>
+            <div class="input-group">
+                <div class="input-group-prepend">
+                    <span class="input-group-text"><i class="fa fa-fw fa-key"></i></span>
+                </div>
+                <textarea class="form-control" name="public_key"><?php echo $certificate_public_key; ?></textarea>
+            </div>
+        </div>
 
         </div>
         <div class="modal-footer bg-white">

--- a/post.php
+++ b/post.php
@@ -4567,11 +4567,22 @@ if(isset($_POST['add_certificate'])){
     $domain = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['domain'])));
     $issued_by = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['issued_by'])));
     $expire = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['expire'])));
+    $public_key = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['public_key'])));
+
+    if (!empty($public_key)) {
+        // Parse the public certificate key. If successful, set attributes from the certificate
+        $public_key_obj = openssl_x509_parse($_POST['public_key']);
+        if ($public_key_obj) {
+            $expire = date('Y-m-d', $public_key_obj['validTo_time_t']);
+            $issued_by = strip_tags($public_key_obj['issuer']['O']);
+        }
+    }
+
     if(empty($expire)){
         $expire = "0000-00-00";
     }
 
-    mysqli_query($mysqli,"INSERT INTO certificates SET certificate_name = '$name', certificate_domain = '$domain', certificate_issued_by = '$issued_by', certificate_expire = '$expire', certificate_created_at = NOW(), certificate_client_id = $client_id, company_id = $session_company_id");
+    mysqli_query($mysqli,"INSERT INTO certificates SET certificate_name = '$name', certificate_domain = '$domain', certificate_issued_by = '$issued_by', certificate_expire = '$expire', certificate_created_at = NOW(), certificate_public_key = '$public_key', certificate_client_id = $client_id, company_id = $session_company_id");
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Certificate', log_action = 'Created', log_description = '$name', log_created_at = NOW(), company_id = $session_company_id, log_user_id = $session_user_id");
@@ -4589,11 +4600,22 @@ if(isset($_POST['edit_certificate'])){
     $domain = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['domain'])));
     $issued_by = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['issued_by'])));
     $expire = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['expire'])));
+    $public_key = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['public_key'])));
+
+    if (!empty($public_key)) {
+        // Parse the public certificate key. If successful, set attributes from the certificate
+        $public_key_obj = openssl_x509_parse($_POST['public_key']);
+        if ($public_key_obj) {
+            $expire = date('Y-m-d', $public_key_obj['validTo_time_t']);
+            $issued_by = strip_tags($public_key_obj['issuer']['O']);
+        }
+    }
+
     if(empty($expire)){
         $expire = "0000-00-00";
     }
 
-    mysqli_query($mysqli,"UPDATE certificates SET certificate_name = '$name', certificate_domain = '$domain', certificate_issued_by = '$issued_by', certificate_expire = '$expire', certificate_updated_at = NOW() WHERE certificate_id = $certificate_id AND company_id = $session_company_id");
+    mysqli_query($mysqli,"UPDATE certificates SET certificate_name = '$name', certificate_domain = '$domain', certificate_issued_by = '$issued_by', certificate_expire = '$expire', certificate_updated_at = NOW(), certificate_public_key = '$public_key' WHERE certificate_id = $certificate_id AND company_id = $session_company_id");
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Certificate', log_action = 'Modified', log_description = '$name', log_created_at = NOW(), company_id = $session_company_id, log_user_id = $session_user_id");


### PR DESCRIPTION
This commit allows you to store the public key for a client certificate. 

If you store a key in the x509 format, it will also read and update the expiry date/issuer fields for you as well. As such, I've removed the "required" html tags from these fields.