### PR TITLE
Client bugs

### DIFF
--- a/add_client_modal.php
+++ b/add_client_modal.php
@@ -144,12 +144,12 @@
             <div class="tab-pane fade" id="pills-contact">
 
               <div class="form-group">
-                <label>Primary Contact</label>
+                <label>Primary Contact <strong class="text-danger">*</strong></label>
                 <div class="input-group">
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-user"></i></span>
                   </div>
-                  <input type="text" class="form-control" name="contact" placeholder="Primary Contact Person"> 
+                  <input type="text" class="form-control" name="contact" placeholder="Primary Contact Person" required autofocus>
                 </div>
               </div>
 

--- a/client.php
+++ b/client.php
@@ -246,7 +246,7 @@ $location_phone = formatPhoneNumber($location_phone);
             <div class="dropdown-divider"></div>
             <a class="dropdown-item" href="#" data-toggle="modal" data-target="#editClientModal<?php echo $client_id; ?>">Edit</a>
             <div class="dropdown-divider"></div>
-            <a class="dropdown-item text-danger" href="post.php?delete_client=<?php echo $client_id; ?>">Delete</a>
+            <a class="dropdown-item text-danger" href="#" data-toggle="modal" data-target="#deleteClientModal<?php echo $client_id; ?>">Delete</a>
           </div>
         </div>
       </div>
@@ -259,6 +259,7 @@ $location_phone = formatPhoneNumber($location_phone);
   include("client_routes.php");
   include("edit_client_modal.php");
   include("add_quick_modal.php");
+  include("delete_client_modal.php");
 
   }
 

--- a/clients.php
+++ b/clients.php
@@ -46,6 +46,12 @@ if(isset($_GET['order'])){
   $order_display = "ASC";
 }
 
+if (empty($_GET['canned_date'])) {
+    //Prevents lots of undefined variable errors.
+    // $dtf and $dtt will be set by the below else to 0000-00-00 / 9999-00-00
+    $_GET['canned_date'] = 'custom';
+}
+
 //Date Filter
 if($_GET['canned_date'] == "custom" AND !empty($_GET['date_from'])){
   $date_from = mysqli_real_escape_string($mysqli,$_GET['date_from']);


### PR DESCRIPTION
Hey, me again :)

Few quick bug fixes.

- Require a primary tech contact be associated when client is created. This prevents an error when ticekts are created from the "general" management page (as no contact is prompted, and one does not exist, the ticket fails to be created).
- Ensure the canned_date is defined in the clients list (clients.php) page, this just prevents a load of PHP's errors (similar to #233)
- Prompt for confirmation when deleting a client from their "banner/summary" page (the bit with contact/billing/support summaries. Contributes to resolving #181, but we still need confirmations for other actions.