### PR TITLE
Secure Cookies

### DIFF
--- a/check_login.php
+++ b/check_login.php
@@ -1,9 +1,13 @@
 <?php
 	
 	if(!isset($_SESSION)){
-    // HTTP Only cookies
-    ini_set("session.cookie_httponly", True);
-    session_start();
+        // HTTP Only cookies
+        ini_set("session.cookie_httponly", True);
+        if($config_https_only){
+            // Tell client to only send cookie(s) over HTTPS
+            ini_set("session.cookie_secure", True);
+        }
+        session_start();
 	}
 
 	//Check to see if setup is enabled

--- a/check_login.php
+++ b/check_login.php
@@ -1,6 +1,8 @@
 <?php
 	
 	if(!isset($_SESSION)){
+    // HTTP Only cookies
+    ini_set("session.cookie_httponly", True);
     session_start();
 	}
 

--- a/login.php
+++ b/login.php
@@ -19,6 +19,11 @@ $user_agent = "$os - $browser";
 // HTTP Only cookies
 ini_set("session.cookie_httponly", True);
 
+// Tell client to only send cookie(s) over HTTPS
+if($config_https_only){
+    ini_set("session.cookie_secure", True);
+}
+
 session_start();
 
 if(isset($_POST['login'])){

--- a/setup.php
+++ b/setup.php
@@ -351,6 +351,7 @@ if(isset($_POST['add_database'])){
   $new_config[] = "\$mysqli = mysqli_connect(\$dbhost, \$dbusername, \$dbpassword, \$database) or die('Database Connection Failed');\n";
   $new_config[] = "\$config_app_name = 'ITFlow';\n";
   $new_config[] = sprintf("\$config_base_url = '%s';\n", addslashes($config_base_url));
+  $new_config[] = "\$config_https_only = TRUE;\n";
 
   file_put_contents("config.php", $new_config);
 


### PR DESCRIPTION
Set Secure flag on cookies, so they are only sent in HTTPS requests by default.
This can be overridden by setting $config_https_only = FALSE in the config.php file.

Note: Browsers seem to bypass this check for localhost sites.