### PR TITLE
Encryption changes

### DIFF
--- a/client_assets.php
+++ b/client_assets.php
@@ -39,7 +39,7 @@ if(isset($_GET['o'])){
 //Rebuild URL
 $url_query_strings_sb = http_build_query(array_merge($_GET,array('sb' => $sb, 'o' => $o)));
 
-$sql = mysqli_query($mysqli,"SELECT SQL_CALC_FOUND_ROWS *, AES_DECRYPT(login_password, '$config_aes_key') AS login_password FROM assets LEFT JOIN contacts ON asset_contact_id = contact_id LEFT JOIN locations ON asset_location_id = location_id LEFT JOIN logins ON login_asset_id = asset_id
+$sql = mysqli_query($mysqli,"SELECT SQL_CALC_FOUND_ROWS * FROM assets LEFT JOIN contacts ON asset_contact_id = contact_id LEFT JOIN locations ON asset_location_id = location_id LEFT JOIN logins ON login_asset_id = asset_id
   WHERE asset_client_id = $client_id 
   AND (asset_name LIKE '%$q%' OR asset_type LIKE '%$q%' OR asset_ip LIKE '%$q%' OR asset_make LIKE '%$q%' OR asset_model LIKE '%$q%' OR asset_serial LIKE '%$q%' OR asset_os LIKE '%$q%' OR contact_name LIKE '%$q%' OR location_name LIKE '%$q%') 
   ORDER BY $sb $o LIMIT $record_from, $record_to");
@@ -178,7 +178,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
 
             $login_id = $row['login_id'];
             $login_username = $row['login_username'];
-            $login_password = $row['login_password'];
+            $login_password = decryptLoginEntry($row['login_password']);
       
           ?>
           <tr>

--- a/client_logins.php
+++ b/client_logins.php
@@ -41,7 +41,7 @@ if(isset($_GET['o'])){
 //Rebuild URL
 $url_query_strings_sb = http_build_query(array_merge($_GET,array('sb' => $sb, 'o' => $o)));
 
-$sql = mysqli_query($mysqli,"SELECT SQL_CALC_FOUND_ROWS *, AES_DECRYPT(login_password, '$config_aes_key') AS login_password FROM logins 
+$sql = mysqli_query($mysqli,"SELECT SQL_CALC_FOUND_ROWS * FROM logins 
   WHERE login_client_id = $client_id 
   AND (login_name LIKE '%$q%' OR login_username LIKE '%$q%' OR login_uri LIKE '%$q%') 
   ORDER BY $sb $o LIMIT $record_from, $record_to");
@@ -112,7 +112,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
             }else{
               $login_username_display = "$login_username<button class='btn btn-sm' data-clipboard-text='$login_username'><i class='far fa-copy text-secondary'></i></button>";
             }
-            $login_password = htmlentities($row['login_password']);
+            $login_password = htmlentities(decryptLoginEntry($row['login_password']));
             $login_otp_secret = $row['login_otp_secret'];
             if(empty($login_otp_secret)){
               $otp_display = "-";

--- a/client_software.php
+++ b/client_software.php
@@ -39,7 +39,7 @@ if(isset($_GET['o'])){
 //Rebuild URL
 $url_query_strings_sb = http_build_query(array_merge($_GET,array('sb' => $sb, 'o' => $o)));
 
-$sql = mysqli_query($mysqli,"SELECT SQL_CALC_FOUND_ROWS *, AES_DECRYPT(login_password, '$config_aes_key') AS login_password FROM software LEFT JOIN logins ON login_software_id = software_id
+$sql = mysqli_query($mysqli,"SELECT SQL_CALC_FOUND_ROWS * FROM software LEFT JOIN logins ON login_software_id = software_id
   WHERE software_client_id = $client_id 
   AND (software_name LIKE '%$q%' OR software_type LIKE '%$q%' OR software_license LIKE '%$q%') 
   ORDER BY $sb $o LIMIT $record_from, $record_to");
@@ -107,7 +107,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
 
             $login_id = $row['login_id'];
             $login_username = $row['login_username'];
-            $login_password = $row['login_password'];
+            $login_password = decryptLoginEntry($row['login_password']);
 
           ?>
           <tr>

--- a/db.sql
+++ b/db.sql
@@ -889,6 +889,7 @@ DROP TABLE IF EXISTS `settings`;
 CREATE TABLE `settings` (
   `company_id` int(11) NOT NULL,
   `config_api_key` varchar(200) DEFAULT NULL,
+  `config_aes_key` varchar(250) DEFAULT NULL COMMENT 'Legacy',
   `config_base_url` varchar(200) DEFAULT NULL,
   `config_smtp_host` varchar(200) DEFAULT NULL,
   `config_smtp_port` int(5) DEFAULT NULL,

--- a/db.sql
+++ b/db.sql
@@ -1163,7 +1163,7 @@ CREATE TABLE `users` (
   `user_email` varchar(200) NOT NULL,
   `user_password` varchar(200) NOT NULL,
   `user_token` varchar(200) DEFAULT NULL,
-  `user_encryption_ciphertext` varchar(200) DEFAULT NULL,
+  `user_specific_encryption_ciphertext` varchar(200) DEFAULT NULL,
   `user_avatar` varchar(200) DEFAULT NULL,
   `user_created_at` datetime NOT NULL,
   `user_updated_at` datetime DEFAULT NULL,

--- a/db.sql
+++ b/db.sql
@@ -1163,6 +1163,7 @@ CREATE TABLE `users` (
   `user_email` varchar(200) NOT NULL,
   `user_password` varchar(200) NOT NULL,
   `user_token` varchar(200) DEFAULT NULL,
+  `user_encryption_ciphertext` varchar(200) DEFAULT NULL,
   `user_avatar` varchar(200) DEFAULT NULL,
   `user_created_at` datetime NOT NULL,
   `user_updated_at` datetime DEFAULT NULL,

--- a/db.sql
+++ b/db.sql
@@ -889,7 +889,6 @@ DROP TABLE IF EXISTS `settings`;
 CREATE TABLE `settings` (
   `company_id` int(11) NOT NULL,
   `config_api_key` varchar(200) DEFAULT NULL,
-  `config_aes_key` varchar(250) DEFAULT NULL,
   `config_base_url` varchar(200) DEFAULT NULL,
   `config_smtp_host` varchar(200) DEFAULT NULL,
   `config_smtp_port` int(5) DEFAULT NULL,

--- a/functions.php
+++ b/functions.php
@@ -368,7 +368,13 @@ function generateUserSessionKey($site_encryption_master_key){
     $_SESSION['user_encryption_session_iv'] = $user_encryption_session_iv;
 
     //Give the user "their" key as a cookie
-    setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/", "", "true", "true");
+    if($config_https_only){
+        setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/", "", "true", "true");
+    }
+    else {
+        // No secure flag
+        setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/", "", "false", "true");
+    }
 }
 
 //Decrypts an encrypted password (website/asset login), returns it as a string

--- a/functions.php
+++ b/functions.php
@@ -368,12 +368,13 @@ function generateUserSessionKey($site_encryption_master_key){
     $_SESSION['user_encryption_session_iv'] = $user_encryption_session_iv;
 
     //Give the user "their" key as a cookie
+    //By default, this should be HTTPS but we can change to HTTP for development via the config.php file
     if($config_https_only){
         setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/", "", "true", "true");
     }
-    else {
-        // No secure flag
-        setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/", "", "false", "true");
+    else{
+        setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/");
+        $_SESSION['alert_message'] = "Unencrypted connection: Using HTTP only.";
     }
 }
 

--- a/functions.php
+++ b/functions.php
@@ -326,7 +326,9 @@ function encryptUserSpecificKey($user_password){
     $user_password_kdhash = hash_pbkdf2('sha256', $user_password, $salt, 100000, 16);
 
     //Encrypt the master key with the users kdf'd hash and the IV
-    $user_encryption_ciphertext = openssl_encrypt($site_encryption_master_key, 'aes-128-cbc', $user_password_kdhash, 0, $iv);
+    $ciphertext = openssl_encrypt($site_encryption_master_key, 'aes-128-cbc', $user_password_kdhash, 0, $iv);
+
+    $user_encryption_ciphertext = $salt . $iv . $ciphertext;
 
     return $user_encryption_ciphertext;
 

--- a/functions.php
+++ b/functions.php
@@ -411,6 +411,16 @@ function encryptLoginEntry($login_password_cleartext){
     return $login_password_ciphertext;
 }
 
+//For migrating/upgrading to the new encryption scheme
+//Have to supply the master key as the cookie might not be set properly (generally requires a refresh)
+function encryptUpgradeLoginEntry($login_password_cleartext, $site_encryption_master_key){
+    $iv = keygen();
 
+    //Encrypt the website/asset login using the master key
+    $ciphertext = openssl_encrypt($login_password_cleartext, 'aes-128-cbc', $site_encryption_master_key, 0, $iv);
+
+    $login_password_ciphertext = $iv . $ciphertext;
+    return $login_password_ciphertext;
+}
 
 ?>

--- a/functions.php
+++ b/functions.php
@@ -369,12 +369,13 @@ function generateUserSessionKey($site_encryption_master_key){
 
     //Give the user "their" key as a cookie
     //By default, this should be HTTPS but we can change to HTTP for development via the config.php file
+    include('config.php');
     if($config_https_only){
         setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/", "", "true", "true");
     }
     else{
         setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/");
-        $_SESSION['alert_message'] = "Unencrypted connection: Using HTTP only.";
+        $_SESSION['alert_message'] = "Unencrypted connection flag set: Using non-secure cookies.";
     }
 }
 

--- a/functions.php
+++ b/functions.php
@@ -159,15 +159,15 @@ function get_device(){
         }
     }
     if ($tablet_browser > 0) {
-           // do something for tablet devices
+           //do something for tablet devices
         return 'Tablet';
     }
     else if ($mobile_browser > 0) {
-           // do something for mobile devices
+           //do something for mobile devices
         return 'Mobile';
     }
     else {
-           // do something for everything else
+           //do something for everything else
         return 'Computer';
     }   
 }
@@ -286,5 +286,130 @@ function mkdir_missing($dir) {
         mkdir($dir);
     }
 }
+
+//Called during initial setup
+//Encrypts the master key with the user's password
+function setupFirstUserSpecificKey($user_password, $site_encryption_master_key){
+    $iv = keygen();
+    $salt = keygen();
+
+    //Generate 128-bit (16 byte/char) kdhash of the users password
+    $user_password_kdhash = hash_pbkdf2('sha256', $user_password, $salt, 100000, 16);
+
+    //Encrypt the master key with the users kdf'd hash and the IV
+    $ciphertext = openssl_encrypt($site_encryption_master_key, 'aes-128-cbc', $user_password_kdhash, 0, $iv);
+
+    $user_encryption_ciphertext = $salt . $iv . $ciphertext;
+
+    return $user_encryption_ciphertext;
+}
+
+/*
+For additional users / password changes
+New Users: Requires the admin setting up their account have the their own Specific/Session key configured
+Password Changes: Will use the current info in the session. Maybe a good idea force logout users after a password change, so that upon login new session info is set fresh..
+-- This logic will need to be in the pass change function itself
+*/
+function encryptUserSpecificKey($user_password){
+    $iv = keygen();
+    $salt = keygen();
+
+    //Get the session info.
+    $user_encryption_session_ciphertext = $_SESSION['user_encryption_session_ciphertext'];
+    $user_encryption_session_iv =  $_SESSION['user_encryption_session_iv'];
+    $user_encryption_session_key = $_COOKIE['user_encryption_session_key'];
+
+    //Decrypt the session key to get the master key
+    $site_encryption_master_key = openssl_decrypt($user_encryption_session_ciphertext, 'aes-128-cbc', $user_encryption_session_key, 0, $user_encryption_session_iv);
+
+    //Generate 128-bit (16 byte/char) kdhash of the users (new) password
+    $user_password_kdhash = hash_pbkdf2('sha256', $user_password, $salt, 100000, 16);
+
+    //Encrypt the master key with the users kdf'd hash and the IV
+    $user_encryption_ciphertext = openssl_encrypt($site_encryption_master_key, 'aes-128-cbc', $user_password_kdhash, 0, $iv);
+
+    return $user_encryption_ciphertext;
+
+}
+
+//Given a ciphertext (incl. IV) and the user's password, returns the site master key
+//Ran at login, to facilitate generateUserSessionKey
+function decryptUserSpecificKey($user_encryption_ciphertext, $user_password){
+    //Get the IV, salt and ciphertext
+    $salt = substr($user_encryption_ciphertext, 0, 16);
+    $iv = substr($user_encryption_ciphertext, 16, 16);
+    $ciphertext = substr($user_encryption_ciphertext, 32);
+
+    //Generate 128-bit (16 byte/char) kdhash of the users password
+    $user_password_kdhash = hash_pbkdf2('sha256', $user_password, $salt, 100000, 16);
+
+    //Use this hash to get the original/master key
+    $site_encryption_master_key = openssl_decrypt($ciphertext, 'aes-128-cbc', $user_password_kdhash, 0, $iv);
+    return $site_encryption_master_key;
+}
+
+/*
+Generates what is probably best described as an session key (ephemeral-ish)
+- Allows us to store the master key on the server whilst the user is using the application, without prompting to type their password everytime they want to decrypt a credential
+- Ciphertext/IV is stored on the server in the users session, encryption key is controlled/provided by the user as a cookie
+- Only the user can decrypt their session ciphertext to get the master key
+- Encryption key never hits the disk in cleartext
+*/
+function generateUserSessionKey($site_encryption_master_key){
+
+    //Generate both of these using keygen()
+    $user_encryption_session_key = keygen();
+    $user_encryption_session_iv = keygen();
+    $user_encryption_session_ciphertext = openssl_encrypt($site_encryption_master_key, 'aes-128-cbc', $user_encryption_session_key, 0, $user_encryption_session_iv);
+
+    //Store ciphertext in the user's session
+    $_SESSION['user_encryption_session_ciphertext'] = $user_encryption_session_ciphertext;
+    $_SESSION['user_encryption_session_iv'] = $user_encryption_session_iv;
+
+    //Give the user "their" key as a cookie
+    setcookie("user_encryption_session_key", $user_encryption_session_key, 0, "/", "", "true", "true");
+}
+
+//Decrypts an encrypted password (website/asset login), returns it as a string
+function decryptLoginEntry($login_password_ciphertext){
+
+    //Split the login into IV and Ciphertext
+    $login_iv =  substr($login_password_ciphertext, 0, 16);
+    $login_ciphertext = $salt = substr($login_password_ciphertext, 16);
+
+    //Get the user session info.
+    $user_encryption_session_ciphertext = $_SESSION['user_encryption_session_ciphertext'];
+    $user_encryption_session_iv =  $_SESSION['user_encryption_session_iv'];
+    $user_encryption_session_key = $_COOKIE['user_encryption_session_key'];
+
+    //Decrypt the session key to get the master key
+    $site_encryption_master_key = openssl_decrypt($user_encryption_session_ciphertext, 'aes-128-cbc', $user_encryption_session_key, 0, $user_encryption_session_iv);
+
+    //Decrypt the login password using the master key
+    $login_password_cleartext = openssl_decrypt($login_ciphertext, 'aes-128-cbc', $site_encryption_master_key, 0, $login_iv);
+    return $login_password_cleartext;
+
+}
+
+//Encrypts a website/asset login password
+function encryptLoginEntry($login_password_cleartext){
+    $iv = keygen();
+
+    //Get the user session info.
+    $user_encryption_session_ciphertext = $_SESSION['user_encryption_session_ciphertext'];
+    $user_encryption_session_iv =  $_SESSION['user_encryption_session_iv'];
+    $user_encryption_session_key = $_COOKIE['user_encryption_session_key'];
+
+    //Decrypt the session key to get the master key
+    $site_encryption_master_key = openssl_decrypt($user_encryption_session_ciphertext, 'aes-128-cbc', $user_encryption_session_key, 0, $user_encryption_session_iv);
+
+    //Encrypt the website/asset login using the master key
+    $ciphertext = openssl_encrypt($login_password_cleartext, 'aes-128-cbc', $site_encryption_master_key, 0, $iv);
+
+    $login_password_ciphertext = $iv . $ciphertext;
+    return $login_password_ciphertext;
+}
+
+
 
 ?>

--- a/functions.php
+++ b/functions.php
@@ -307,8 +307,7 @@ function setupFirstUserSpecificKey($user_password, $site_encryption_master_key){
 /*
 For additional users / password changes
 New Users: Requires the admin setting up their account have the their own Specific/Session key configured
-Password Changes: Will use the current info in the session. Maybe a good idea force logout users after a password change, so that upon login new session info is set fresh..
--- This logic will need to be in the pass change function itself
+Password Changes: Will use the current info in the session.
 */
 function encryptUserSpecificKey($user_password){
     $iv = keygen();

--- a/get_settings.php
+++ b/get_settings.php
@@ -6,7 +6,6 @@ $row = mysqli_fetch_array($sql_settings);
 
 //General
 $config_api_key = $row['config_api_key'];
-$config_aes_key = $row['config_aes_key'];
 $config_base_url = $row['config_base_url'];
 
 //Mail

--- a/get_settings.php
+++ b/get_settings.php
@@ -6,6 +6,7 @@ $row = mysqli_fetch_array($sql_settings);
 
 //General
 $config_api_key = $row['config_api_key'];
+$config_aes_key = $row['config_aes_key']; //Legacy
 $config_base_url = $row['config_base_url'];
 
 //Mail

--- a/login.php
+++ b/login.php
@@ -46,9 +46,11 @@ if(isset($_POST['login'])){
     $user_id = $row['user_id'];
 
     //Setup encryption session key
-    $user_encryption_ciphertext = $row['user_specific_encryption_ciphertext'];
-    $site_encryption_master_key = decryptUserSpecificKey($user_encryption_ciphertext, $password);
-    generateUserSessionKey($site_encryption_master_key);
+    if(isset($row['user_specific_encryption_ciphertext'])){
+        $user_encryption_ciphertext = $row['user_specific_encryption_ciphertext'];
+        $site_encryption_master_key = decryptUserSpecificKey($user_encryption_ciphertext, $password);
+        generateUserSessionKey($site_encryption_master_key);
+    }
 
     if(empty($token)){
       $_SESSION['logged'] = TRUE;

--- a/login.php
+++ b/login.php
@@ -45,6 +45,11 @@ if(isset($_POST['login'])){
     $user_name = $row['user_name'];
     $user_id = $row['user_id'];
 
+    //Setup encryption session key
+    $user_encryption_ciphertext = $row['user_specific_encryption_ciphertext'];
+    $site_encryption_master_key = decryptUserSpecificKey($user_encryption_ciphertext, $password);
+    generateUserSessionKey($site_encryption_master_key);
+
     if(empty($token)){
       $_SESSION['logged'] = TRUE;
       mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Login', log_action = 'Success', log_description = '$user_name successfully logged in', log_ip = '$ip', log_user_agent = '$user_agent', log_created_at = NOW(), log_user_id = $user_id");

--- a/post.php
+++ b/post.php
@@ -6565,11 +6565,12 @@ if(isset($_GET['logout'])){
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Logout', log_action = 'Success', log_description = '$session_name logged out', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_created_at = NOW(), log_user_id = $session_user_id");
 
     session_start();
-    session_destroy();
 
+    setcookie("user_encryption_session_key", '', time() - 3600, "/");
     unset($_COOKIE['user_encryption_session_key']);
-    setcookie("user_encryption_session_key", '', time() - 3600, "/", "", "true", "true");
 
+    session_unset();
+    session_destroy();
 
     header('Location: login.php');
 }

--- a/post.php
+++ b/post.php
@@ -1039,6 +1039,7 @@ if(isset($_POST['encryption_update'])){
     if(!password_verify($password, $row['user_password'])){
         $_SESSION['alert_message'] = "User password incorrect.";
         header("Location: " . $_SERVER["HTTP_REFERER"]);
+        exit();
     }
 
     //First, check if this user is setup for the new encryption setup

--- a/post.php
+++ b/post.php
@@ -1076,7 +1076,7 @@ if(isset($_POST['encryption_update'])){
 
         //Invalidate user passwords
         //If we don't do this, users won't be able to see the new passwords properly, and could potentially add passwords that can never be decrypted
-        mysqli_query($mysqli, "UPDATE users SET login_password = 'Invalid due to upgrade'");
+        mysqli_query($mysqli, "UPDATE users SET user_password = 'Invalid due to upgrade'");
         $extended_log_description = ", invalidated all user passwords";
         echo "Invalidated all user passwords. You must re-set them from this user account.<br>";
     }

--- a/post.php
+++ b/post.php
@@ -1077,7 +1077,7 @@ if(isset($_POST['encryption_update'])){
 
         //Invalidate user passwords
         //If we don't do this, users won't be able to see the new passwords properly, and could potentially add passwords that can never be decrypted
-        mysqli_query($mysqli, "UPDATE users SET user_password = 'Invalid due to upgrade' WHERE user_id NOT IN ($userion_user_id)");
+        mysqli_query($mysqli, "UPDATE users SET user_password = 'Invalid due to upgrade' WHERE user_id NOT IN ($session_user_id)");
         $extended_log_description = ", invalidated all user passwords";
         echo "Invalidated all user passwords. You must re-set them from this user account.<br>";
     }

--- a/post.php
+++ b/post.php
@@ -4439,14 +4439,14 @@ if(isset($_POST['add_login'])){
     $name = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['name'])));
     $uri = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['uri'])));
     $username = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['username'])));
-    $password = trim(mysqli_real_escape_string($mysqli,$_POST['password']));
+    $password = trim(mysqli_real_escape_string($mysqli,encryptLoginEntry($_POST['password'])));
     $otp_secret = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['otp_secret'])));
     $note = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['note'])));
     $vendor_id = intval($_POST['vendor']);
     $asset_id = intval($_POST['asset']);
     $software_id = intval($_POST['software']);
 
-    mysqli_query($mysqli,"INSERT INTO logins SET login_name = '$name', login_uri = '$uri', login_username = '$username', login_password = AES_ENCRYPT('$password','$config_aes_key'), login_otp_secret = '$otp_secret', login_note = '$note', login_created_at = NOW(), login_vendor_id = $vendor_id, login_asset_id = $asset_id, login_software_id = $software_id, login_client_id = $client_id, company_id = $session_company_id");
+    mysqli_query($mysqli,"INSERT INTO logins SET login_name = '$name', login_uri = '$uri', login_username = '$username', login_password = '$password', login_otp_secret = '$otp_secret', login_note = '$note', login_created_at = NOW(), login_vendor_id = $vendor_id, login_asset_id = $asset_id, login_software_id = $software_id, login_client_id = $client_id, company_id = $session_company_id");
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Login', log_action = 'Created', log_description = '$name', log_created_at = NOW(), company_id = $session_company_id, log_user_id = $session_user_id");
@@ -5681,7 +5681,7 @@ if(isset($_GET['export_client_pdf'])){
     $sql_locations = mysqli_query($mysqli,"SELECT * FROM locations WHERE location_client_id = $client_id ORDER BY location_name ASC");
     $sql_vendors = mysqli_query($mysqli,"SELECT * FROM vendors WHERE vendor_client_id = $client_id ORDER BY vendor_name ASC");
     if(isset($_GET['passwords'])){
-        $sql_logins = mysqli_query($mysqli,"SELECT *, AES_DECRYPT(login_password, '$config_aes_key') AS login_password FROM logins WHERE login_client_id = $client_id ORDER BY login_name ASC");
+        $sql_logins = mysqli_query($mysqli,"SELECT * FROM logins WHERE login_client_id = $client_id ORDER BY login_name ASC");
     }
     $sql_assets = mysqli_query($mysqli,"SELECT * FROM assets WHERE asset_client_id = $client_id ORDER BY asset_type ASC");
     $sql_networks = mysqli_query($mysqli,"SELECT * FROM networks WHERE network_client_id = $client_id ORDER BY network_name ASC");
@@ -6022,7 +6022,7 @@ if(isset($_GET['export_client_pdf'])){
                         while($row = mysqli_fetch_array($sql_logins)){
                             $login_name = $row['login_name'];
                             $login_username = $row['login_username'];
-                            $login_password = $row['login_password'];
+                            $login_password = decryptLoginEntry($row['login_password']);
                             $login_uri = $row['login_uri'];
                             $login_note = $row['login_note'];
                         ?>

--- a/post.php
+++ b/post.php
@@ -1052,8 +1052,9 @@ if(isset($_POST['encryption_update'])){
         $update_table = mysqli_query($mysqli, "ALTER TABLE `users` ADD `user_specific_encryption_ciphertext` VARCHAR(200) NULL AFTER `user_avatar`; ");
 
         if(!$update_table){
-            echo "Error adding ciphertext column (user_specific_encryption_ciphertext) to users table.";
-            echo "Either there was a connection/permissions issue or the column already exists due to a upgrade already taking place?<br>";
+            echo "Error adding ciphertext column (user_specific_encryption_ciphertext) to users table.<br>";
+            echo "Either there was a connection/permissions issue or the column already exists (due to a upgrade already taking place?)<br>";
+            echo "Quitting to prevent compromising data integrity. Delete the column if you are sure you need to upgrade (presuming it contains no data).<br>";
             exit();
         }
 
@@ -1094,7 +1095,7 @@ if(isset($_POST['encryption_update'])){
     echo "Upgraded $count records.<br>";
 
     //Logging
-    mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Settings', log_action = 'Migrate', log_description = '$session_name upgraded $session_company_id logins to the new encryption scheme$extended_log_description', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_created_at = NOW(), log_user_id = $session_user_id, company_id = $session_company_id");
+    mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Settings', log_action = 'Migrate', log_description = '$session_name upgraded company ID $session_company_id logins ($count total) to the new encryption scheme$extended_log_description', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_created_at = NOW(), log_user_id = $session_user_id, company_id = $session_company_id");
 
     echo "Migration for company successful.<br>";
     $_SESSION['alert_message'] = "Migration for company successful.";

--- a/post.php
+++ b/post.php
@@ -1077,7 +1077,7 @@ if(isset($_POST['encryption_update'])){
 
         //Invalidate user passwords
         //If we don't do this, users won't be able to see the new passwords properly, and could potentially add passwords that can never be decrypted
-        mysqli_query($mysqli, "UPDATE users SET user_password = 'Invalid due to upgrade'");
+        mysqli_query($mysqli, "UPDATE users SET user_password = 'Invalid due to upgrade' WHERE user_id NOT IN ($userion_user_id)");
         $extended_log_description = ", invalidated all user passwords";
         echo "Invalidated all user passwords. You must re-set them from this user account.<br>";
     }

--- a/settings-backup.php
+++ b/settings-backup.php
@@ -4,13 +4,35 @@
 
 <div class="card card-dark">
   <div class="card-header">
-    <h3 class="card-title"><i class="fa fa-fw fa-database"></i> Backup</h3>
+    <h3 class="card-title"><i class="fa fa-fw fa-database"></i> Backup Database</h3>
   </div>
   <div class="card-body">
     <center>
       <a class="btn btn-primary btn-lg p-3" href="post.php?download_database"><i class="fa fa-fw fa-4x fa-download"></i><br><br>Download Database</a>
     </center>
   </div>
+</div>
+
+<br> <br>
+
+<div class="card card-dark">
+    <div class="card-header">
+        <h3 class="card-title"><i class="fa fa-fw fa-key"></i> Backup Master Encryption Key</h3>
+    </div>
+    <div class="card-body">
+        <center>
+            <!--<a class="btn btn-primary btn-lg p-3" href="post.php?download_database"><i class="fa fa-fw fa-4x fa-key"></i><br><br>Get AES Master Key</a> -->
+            <form action="post.php" method="POST">
+                <div class="input-group col-3">
+                    <input type="password" class="form-control" placeholder="Account Password" name="password" value="" required="">
+                </div>
+                <br>
+                <div class="input-group col-3 offset-2">
+                    <button class="btn btn-primary btn-lg p-3" type="submit" name="backup_master_key"><i class="fa fa-fw fa-2x fa-key"></i><br>Get Master Key</button>
+                </div>
+            </form>
+        </center>
+    </div>
 </div>
 
 <?php include("footer.php");

--- a/settings-general.php
+++ b/settings-general.php
@@ -23,20 +23,6 @@
       </div>
 
       <div class="form-group">
-        <label>AES Decryption Key</label>
-        <div class="input-group">
-          <div class="input-group-prepend">
-            <span class="input-group-text"><i class="fa fa-fw fa-key"></i></span>
-          </div>
-          <input type="password" class="form-control" data-toggle="password" name="config_aes_key" placeholder="Key used to decrypt passwords" value="<?php echo $config_aes_key; ?>">
-          <div class="input-group-append">
-            <span class="input-group-text"><i class="fa fa-fw fa-eye"></i></span>
-          </div>
-        </div>
-        <small class="form-text text-muted">This will also update the key on all client logins</small>
-      </div>
-
-      <div class="form-group">
         <label>Base URL</label>
         <div class="input-group">
           <div class="input-group-prepend">

--- a/settings-update.php
+++ b/settings-update.php
@@ -61,4 +61,60 @@ $git_log = shell_exec("git log master..origin/master --pretty=format:'<tr><td>%h
   </div>
 </div>
 
+<!-- Updater to upgrade to new encryption -->
+<div class="card card-dark">
+    <div class="card-header">
+        <h3 class="card-title"><i class="fa fa-fw fa-wrench"></i> Update AES Key</h3>
+    </div>
+    <div class="card-body">
+    <center>
+        <div class="col-8">
+            <div class="alert alert-danger" role="alert">
+                <strong>You only need to continue with this action if you are upgrading/migrating to the new encryption setup.</strong>
+                <ul>
+                    <li>Please take a backup of your current AES config key (for each company), and your 'logins' database table</li>
+                    <li>Please ensure you have access to ALL companies registered under this instance, if using multiple companies. Only one user should perform the entire migration.</li>
+                    <li>This activity will invalidate all existing user passwords. You must set them again using THIS user account.</li>
+                </ul>
+            </div>
+        </div>
+<?php
+
+//Get current settings
+include_once('get_settings.php');
+echo "Current Company ID: $session_company_id <br>";
+echo "Current User ID: $session_user_id <br>";
+
+if ($config_aes_key) {
+    echo "Current AES key:  $config_aes_key <br><br>";
+    echo "<b>Below are the decrypted credentials for five login entries, please confirm they show and are correct before continuing. <br>Do NOT continue if no entries are shown or if the decrypted passwords are incorrect.</b><br>";
+    $sql = mysqli_query($mysqli,"SELECT *, AES_DECRYPT(login_password, '$config_aes_key') AS login_password FROM logins WHERE (company_id = '$session_company_id' AND login_password IS NOT NULL) LIMIT 5");
+    foreach ($sql as $row){
+        echo $row['login_username'] . ":" . $row['login_password'];
+        echo "<br>";
+    }
+    echo "<br>";
+    ?>
+
+    <form method="POST" action="post.php">
+        <div class="form-group">
+            <div class="input-group col-3">
+                <input type="password" class="form-control" placeholder="Account Password" name="password" value="" required="">
+            </div>
+            <br>
+            <button type="submit" class="btn btn-danger" name="encryption_update">Update encryption scheme for this company</button>
+        </div>
+    </form>
+<?php
+}
+else {
+    echo "Config AES key is not set for this company.<br>";
+    echo "Please ensure upgrade is required. If you are sure you need to update, ensure the AES key is for this company.";
+}
+
+?>
+    </center>
+    </div>
+</div>
+
 <?php include("footer.php");

--- a/settings-update.php
+++ b/settings-update.php
@@ -70,7 +70,7 @@ $git_log = shell_exec("git log master..origin/master --pretty=format:'<tr><td>%h
     <center>
         <div class="col-8">
             <div class="alert alert-danger" role="alert">
-                <strong>You only need to continue with this action if you are upgrading/migrating to the new encryption setup.</strong>
+                <strong>You only need to continue with this action if you are upgrading/migrating to the new (post Jan 2022) encryption setup.</strong>
                 <ul>
                     <li>Please take a backup of your current AES config key (for each company), and your 'logins' database table</li>
                     <li>Please ensure you have access to ALL companies registered under this instance, if using multiple companies. Only one user should perform the entire migration.</li>
@@ -86,7 +86,7 @@ echo "Current Company ID: $session_company_id <br>";
 echo "Current User ID: $session_user_id <br>";
 
 if ($config_aes_key) {
-    echo "Current AES key:  $config_aes_key <br><br>";
+    echo "Current (legacy) AES key:  $config_aes_key <br><br>";
     echo "<b>Below are the decrypted credentials for five login entries, please confirm they show and are correct before continuing. <br>Do NOT continue if no entries are shown or if the decrypted passwords are incorrect.</b><br>";
     $sql = mysqli_query($mysqli,"SELECT *, AES_DECRYPT(login_password, '$config_aes_key') AS login_password FROM logins WHERE (company_id = '$session_company_id' AND login_password IS NOT NULL) LIMIT 5");
     foreach ($sql as $row){

--- a/settings-update.php
+++ b/settings-update.php
@@ -102,6 +102,7 @@ if ($config_aes_key) {
                 <input type="password" class="form-control" placeholder="Account Password" name="password" value="" required="">
             </div>
             <br>
+            <p>Warning: This action is irreversible. Do NOT proceed without a backup.</p>
             <button type="submit" class="btn btn-danger" name="encryption_update">Update encryption scheme for this company</button>
         </div>
     </form>
@@ -109,7 +110,7 @@ if ($config_aes_key) {
 }
 else {
     echo "Config AES key is not set for this company.<br>";
-    echo "Please ensure upgrade is required. If you are sure you need to update, ensure the AES key is for this company.";
+    echo "Please ensure upgrade is required. If you are sure you need to update, ensure the AES key is set correctly for this company.";
 }
 
 ?>

--- a/setup.php
+++ b/setup.php
@@ -399,7 +399,13 @@ if(isset($_POST['add_user'])){
   $email = trim(strip_tags(mysqli_real_escape_string($mysqli,$_POST['email'])));
   $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
 
-  mysqli_query($mysqli,"INSERT INTO users SET user_name = '$name', user_email = '$email', user_password = '$password', user_created_at = NOW()");
+  //Generate master encryption key
+  $site_encryption_master_key = keygen();
+
+  //Generate user specific key
+  $user_specific_encryption_ciphertext = setupFirstUserSpecificKey($_POST['password'], $site_encryption_master_key);
+
+  mysqli_query($mysqli,"INSERT INTO users SET user_name = '$name', user_email = '$email', user_password = '$password', user_specific_encryption_ciphertext = '$user_specific_encryption_ciphertext', user_created_at = NOW()");
 
   $user_id = mysqli_insert_id($mysqli);
 
@@ -480,7 +486,6 @@ if(isset($_POST['add_company_settings'])){
   $company_id = mysqli_insert_id($mysqli);
   $config_base_url = $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']);
   $config_api_key = keygen();
-  $config_aes_key = keygen();
 
   mkdir_missing("uploads/clients/$company_id");
   file_put_contents("uploads/clients/$company_id/index.php", "");
@@ -536,7 +541,7 @@ if(isset($_POST['add_company_settings'])){
   //Set User Company Permissions
   mysqli_query($mysqli,"INSERT INTO user_companies SET user_id = $user_id, company_id = $company_id");
  
-  mysqli_query($mysqli,"INSERT INTO settings SET company_id = $company_id, config_invoice_prefix = 'INV-', config_invoice_next_number = 1, config_recurring_prefix = 'REC-', config_recurring_next_number = 1, config_invoice_overdue_reminders = '1,3,7', config_quote_prefix = 'QUO-', config_quote_next_number = 1, config_api_key = '$config_api_key', config_aes_key = '$config_aes_key', config_recurring_auto_send_invoice = 1, config_default_net_terms = 7, config_send_invoice_reminders = 1, config_enable_cron = 0, config_ticket_next_number = 1, config_base_url = '$config_base_url'");
+  mysqli_query($mysqli,"INSERT INTO settings SET company_id = $company_id, config_invoice_prefix = 'INV-', config_invoice_next_number = 1, config_recurring_prefix = 'REC-', config_recurring_next_number = 1, config_invoice_overdue_reminders = '1,3,7', config_quote_prefix = 'QUO-', config_quote_next_number = 1, config_api_key = '$config_api_key', config_recurring_auto_send_invoice = 1, config_default_net_terms = 7, config_send_invoice_reminders = 1, config_enable_cron = 0, config_ticket_next_number = 1, config_base_url = '$config_base_url'");
 
   //Create Some Data
 


### PR DESCRIPTION
Further to our discussion in #264, this pull changes the way that login entries are encrypted in the database.

At setup, a "master" AES key is generated (like before), only now it is encrypted with the initial user's password. Specifically, this is done using PBKDF2 and a salt to generate a 128-bit key (as passwords may be more or less than 16 chars). AES-128-CBC with an IV is then used to generate the encrypted password.

For example, my password of "itflow" is stored as: "$2y$10$dPiyQeQIajgGn/ZZwO30pOwExu6pKNPN4.ON5XsXgovslC2hzDqDS" in the database (the first 32 characters are the salt & iv).

Upon login, the user's password is used to decrypt their Specific Key in order to retrieve the master key.
I didn't want to store the master key in plaintext in the database or in the session (disk) so we now encrypt the master key again (with the users "session key") and store the ciphertext in the users session and the encryption key as a client cookie. 
In theory, this means that only this particular user will be able to access the master key by providing the cookie in a HTTPS request.
As soon as the user logs out, the session is destroyed and the cookie is unset. All that is left at that point would be the encrypted Specific key in the database.

All logins are encrypted using the master key and an IV to ensure that each login is secure.

The master key never hits the server disk. The only time it is shown to the user is at http://127.0.0.1/itflow/settings-backup.php to allow it to be backed up. This still probably needs a little bit of work to restrict this based on user role?

I think these changes should cover everything needed for this to work initially. This will require a reinstall to get things set up properly. The main functions are included in the functions.php file.

Please let me know your thoughts? :)