### PR TITLE
Commenting for now

### DIFF
--- a/get_credential.php
+++ b/get_credential.php
@@ -2,16 +2,16 @@
 /*
 
 // Headers to allow extensions access (CORS)
-$chrome_id = "to-be-confirmed";
+$chrome_id = "chrome-extension://afgpakhonllnmnomchjhidealcpmnegc";
 $firefox_id = "moz-extension://857479e9-3992-4e99-9a5e-b514d2ad0a82";
-$http_origin = $_SERVER['HTTP_ORIGIN'];
-// Note, this IF doesn't seem to work currently either.
-// Additionally, will require cookies set to SameSite None.
-if ($http_origin == "$chrome_id" || $http_origin == "$firefox_id")
-{
-    header("Access-Control-Allow-Origin: $http_origin");
-    header("Access-Control-Allow-Credentials: true");
+
+if (isset($_SERVER['HTTP_ORIGIN'])) {
+    if($_SERVER['HTTP_ORIGIN'] == $chrome_id OR $_SERVER['HTTP_ORIGIN'] == $firefox_id){
+        header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+        header('Access-Control-Allow-Credentials: true');
+    }
 }
+// Additionally, will require cookies set to SameSite None.
 
 include("config.php");
 include("functions.php");
@@ -64,16 +64,18 @@ if($session_user_role < 4){
 
 if(isset($_GET['host'])){
 
-    $url = trim(strip_tags(mysqli_real_escape_string($mysqli,$_GET['host'])));
+    if(!empty($_GET['host'])){
+        $url = trim(strip_tags(mysqli_real_escape_string($mysqli,$_GET['host'])));
 
-    $sql_logins = mysqli_query($mysqli, "SELECT * FROM logins WHERE (login_uri = '$url' AND company_id = '$session_company_id') LIMIT 1");
+        $sql_logins = mysqli_query($mysqli, "SELECT * FROM logins WHERE (login_uri = '$url' AND company_id = '$session_company_id') LIMIT 1");
 
-    if(mysqli_num_rows($sql_logins) > 0){
-        $row = mysqli_fetch_array($sql_logins);
-        $data['found'] = "TRUE";
-        $data['username'] = htmlentities($row['login_username']);
-        $data['password'] = decryptLoginEntry($row['login_password']);
-        echo json_encode($data);
+        if(mysqli_num_rows($sql_logins) > 0){
+            $row = mysqli_fetch_array($sql_logins);
+            $data['found'] = "TRUE";
+            $data['username'] = htmlentities($row['login_username']);
+            $data['password'] = decryptLoginEntry($row['login_password']);
+            echo json_encode($data);
+        }
     }
 }
 

--- a/get_credential.php
+++ b/get_credential.php
@@ -1,8 +1,12 @@
 <?php
+/*
+
 // Headers to allow extensions access (CORS)
 $chrome_id = "to-be-confirmed";
-$firefox_id = "to-be-confirmed";
+$firefox_id = "moz-extension://857479e9-3992-4e99-9a5e-b514d2ad0a82";
 $http_origin = $_SERVER['HTTP_ORIGIN'];
+// Note, this IF doesn't seem to work currently either.
+// Additionally, will require cookies set to SameSite None.
 if ($http_origin == "$chrome_id" || $http_origin == "$firefox_id")
 {
     header("Access-Control-Allow-Origin: $http_origin");


### PR DESCRIPTION
RE: https://github.com/johnnyq/itflow/pull/274

**Commenting this out, for now, will need to work on it further & rethink the logic re samesite....**

@johnnyq - Mixed news on this I'm afraid. The Firefox team approved my extension for the grand total of an hour before revoking it for not being "appealing" enough, despite it being marked as experimental. I don't suppose you have a logo for ITFlow we can use lol? 

> Content rejected by unicorn2020 10 minutes ago
To help users discover your extension and decide if they want to install it, please include more information in your add-on listing. Here are a few tips: 
>-Your extension’s summary should clearly and concisely explain what your extension does. 
>- Use the description field to describe what the extension does and how it benefits the user. 
>- Add screenshots to show your extension in action and to highlight key features. 
>For more tips on how to create an appealing listing, please visit https://developer.mozilla.org/Add-ons/Listing.

Besides that, I've discovered a bit of an issue that didn't show up in testing regarding using the user's cookies to authenticate/decrypt logins. It seems that in addition to CORS, the "Samesite" value for the cookie needs to be set to "None" for it to be sent with the extension's background request. ITFlow doesn't set any Samesite attribute & it seems that browsers now interpret that as "Lax" (they won't send the cookie).
I have no issue setting this to "None" for the decryption key (as it's basically useless alone) but allowing the session cookie to be set with samesite = none would open the ITFlow system up to [cross-site request forgery](https://simonwillison.net/2021/Aug/3/samesite/) (the exact issue Samesite has been introduced to mitigate). Note though that CSRF is all about making users perform bad actions (like logging out/deleting something if the attacker knows the URL to send the user to) - there's no information leaked/disclosed to the attacker in most cases.

I'm probably going to have to go for a slightly different approach... 
1. Something like giving authorized users a token (think like an API key) as a cookie and setting that and their session decryption key as SameSite=None. Then validate the token to allow users credential access. I like this approach as it requires the user to be logged into ITFlow to login to sites - makes it easier to rotate/revoke access?
2. Alternatively, we could have users manually set that token from within the browser extension (in addition to setting the site address). It'll then be sent with requests automatically, no need to sign into ITFlow (though we'll still have to set the session key to SameSite None).

They're the same idea, just one requires more user effort. I'm leaning towards the first for simplicity on the user side. Which of these do you like the sound of more? 