### PR TITLE
Move network edit modal data processing to AJAX

### DIFF
--- a/client_network_edit_modal.php
+++ b/client_network_edit_modal.php
@@ -1,14 +1,14 @@
-<div class="modal" id="editNetworkModal<?php echo $network_id; ?>" tabindex="-1">
+<div class="modal" id="editNetworkModal" tabindex="-1">
   <div class="modal-dialog">
     <div class="modal-content bg-dark">
       <div class="modal-header">
-        <h5 class="modal-title"><i class="fa fa-fw fa-network-wired"></i> <?php echo $network_name; ?></h5>
+        <h5 class="modal-title"><i class="fa fa-fw fa-network-wired"></i><span id="edit_network_name_header"></span></h5>
         <button type="button" class="close text-white" data-dismiss="modal">
           <span>&times;</span>
         </button>
       </div>
       <form action="post.php" method="post" autocomplete="off">
-        <input type="hidden" name="network_id" value="<?php echo $network_id; ?>">
+        <input type="hidden" name="network_id" id="edit_network_id" value="">
         <div class="modal-body bg-white">    
           
           <div class="form-group">
@@ -17,7 +17,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-ethernet"></i></span>
               </div>
-              <input type="text" class="form-control" name="name" placeholder="Network name (VLAN, WAN, LAN2 etc)"  value="<?php echo $network_name; ?>" required>
+              <input type="text" class="form-control" id="edit_network_name" name="name" placeholder="Network name (VLAN, WAN, LAN2 etc)" required>
             </div>
           </div>
 
@@ -27,7 +27,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-tag"></i></span>
               </div>
-              <input type="number" class="form-control" name="vlan" placeholder="ex. 20" value="<?php echo $network_vlan; ?>" data-inputmask="'mask': '9999'">
+              <input type="number" class="form-control" id="edit_network_vlan" name="vlan" placeholder="ex. 20" data-inputmask="'mask': '9999'">
             </div>
           </div>
           
@@ -37,7 +37,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-network-wired"></i></span>
               </div>
-              <input type="text" class="form-control" name="network" placeholder="Network ex 192.168.1.0/24" value="<?php echo $network; ?>" required>
+              <input type="text" class="form-control" id="edit_network_cidr" name="network" placeholder="Network ex 192.168.1.0/24" required>
             </div>
           </div>
         
@@ -47,7 +47,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-route"></i></span>
               </div>
-              <input type="text" class="form-control" name="gateway" placeholder="ex 192.168.1.1" value="<?php echo $network_gateway; ?>" data-inputmask="'alias': 'ip'" data-mask required> 
+              <input type="text" class="form-control" id="edit_network_gw" name="gateway" placeholder="ex 192.168.1.1" data-inputmask="'alias': 'ip'" data-mask required>
             </div>
           </div>
 
@@ -57,7 +57,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-server"></i></span>
               </div>
-              <input type="text" class="form-control" name="dhcp_range" placeholder="ex 192.168.1.11-199" value="<?php echo $network_dhcp_range; ?>">
+              <input type="text" class="form-control" id="edit_network_dhcp" name="dhcp_range" placeholder="ex 192.168.1.11-199">
             </div>
           </div>
 
@@ -67,20 +67,8 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-map-marker-alt"></i></span>
               </div>
-              <select class="form-control select2" name="location">
+              <select class="form-control select2" id="edit_network_location" name="location">
                 <option value="">- Location -</option>
-                <?php 
-                
-                $sql_locations = mysqli_query($mysqli,"SELECT * FROM locations WHERE (location_archived_at > '$network_created_at' OR location_archived_at IS NULL) AND location_client_id = $client_id ORDER BY location_name ASC"); 
-                while($row = mysqli_fetch_array($sql_locations)){
-                  $location_id_select = $row['location_id'];
-                  $location_name_select = $row['location_name'];
-                ?>
-                <option <?php if($network_location_id == $location_id_select){ echo "selected"; } ?> value="<?php echo $location_id_select; ?>"><?php echo $location_name_select; ?></option>
-                
-                <?php
-                }
-                ?>
               </select>
             </div>
           </div>

--- a/client_networks.php
+++ b/client_networks.php
@@ -1,4 +1,58 @@
-<?php 
+<?php
+
+?>
+
+<script>
+    function populateNetworkEditModal(client_id, network_id) {
+        //alert (network_id)
+
+        // Send a GET request to post.php as post.php?network_get_json_details=true&client_id=NUM&network_id=NUM
+        jQuery.get(
+            "post.php",
+            {network_get_json_details: 'true', client_id: client_id, network_id: network_id},
+            function(data){
+
+                // If we get a response from post.php, parse it as JSON
+                const response = JSON.parse(data);
+
+                // Access the network (only one!) and locations (possibly multiple)
+                const network = response.network[0];
+                const locations = response.locations;
+
+                // Populate the network modal fields
+                document.getElementById("edit_network_name_header").innerText = " " + network.network_name;
+                document.getElementById("edit_network_id").value = network_id;
+                document.getElementById("edit_network_name").value = network.network_name;
+                document.getElementById("edit_network_vlan").value = network.network_vlan;
+                document.getElementById("edit_network_cidr").value = network.network;
+                document.getElementById("edit_network_gw").value = network.network_gateway;
+                document.getElementById("edit_network_dhcp").value = network.network_dhcp_range;
+
+                // Select the location dropdown
+                var location_dropdown = document.getElementById("edit_network_location");
+
+                // Clear location dropdown
+                var i, L = location_dropdown.options.length -1;
+                for(i = L; i >= 0; i--) {
+                    location_dropdown.remove(i);
+                }
+                location_dropdown[location_dropdown.length] = new Option('- Location -', '0');
+
+                // Populate location dropdown
+                locations.forEach(location => {
+                    if(parseInt(location.location_id) == parseInt(network.network_location_id)){
+                        location_dropdown[location_dropdown.length] = new Option(location.location_name, location.location_id, true, true);
+                    }
+                    else{
+                        location_dropdown[location_dropdown.length] = new Option(location.location_name, location.location_id);
+                    }
+                });
+            }
+        );
+    }
+</script>
+
+<?php
 
 //Paging
 if(isset($_GET['p'])){
@@ -113,7 +167,6 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
             }else{
               $network_dhcp_range_display = $network_dhcp_range;
             }
-            $network_created_at = $row['network_created_at'];
             $network_location_id = $row['network_location_id'];
             $location_name = $row['location_name'];
             if(empty($location_name)){
@@ -126,7 +179,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <tr>
             <th>
               <i class="fa fa-fw fa-network-wired text-secondary"></i> 
-              <a class="text-dark" href="#" data-toggle="modal" data-target="#editNetworkModal<?php echo $network_id; ?>"><?php echo $network_name; ?></a></th>
+              <a class="text-dark" href="#" data-toggle="modal" onclick="populateNetworkEditModal(<?php echo $client_id, ",", $network_id ?>)" data-target="#editNetworkModal"><?php echo $network_name; ?></a></th>
             <td><?php echo $network_vlan_display; ?></td>
             <td><?php echo $network; ?></td>
             <td><?php echo $network_gateway; ?></td>
@@ -138,7 +191,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
                   <i class="fas fa-ellipsis-h"></i>
                 </button>
                 <div class="dropdown-menu">
-                  <a class="dropdown-item" href="#" data-toggle="modal" data-target="#editNetworkModal<?php echo $network_id; ?>">Edit</a>
+                  <a class="dropdown-item" href="#" data-toggle="modal" onclick="populateNetworkEditModal(<?php echo $client_id, ",", $network_id ?>)" data-target="#editNetworkModal">Edit</a>
                   <div class="dropdown-divider"></div>
                   <a class="dropdown-item text-danger" href="post.php?delete_network=<?php echo $network_id; ?>">Delete</a>
                 </div>
@@ -147,8 +200,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           </tr>
 
           <?php
-          
-          include("client_network_edit_modal.php");
+
           }
           
           ?>
@@ -160,4 +212,9 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
   </div>
 </div>
 
-<?php include("client_network_add_modal.php"); ?>
+<?php
+
+include("client_network_edit_modal.php");
+include("client_network_add_modal.php");
+
+?>

--- a/post.php
+++ b/post.php
@@ -4889,6 +4889,27 @@ if(isset($_POST['edit_network'])){
 
 }
 
+if(isset($_GET['network_get_json_details'])){
+    $network_id = intval($_GET['network_id']);
+    $client_id = intval($_GET['client_id']);
+
+    $network_sql = mysqli_query($mysqli,"SELECT * FROM networks 
+  WHERE network_id = $network_id
+  AND network_client_id = $client_id");
+    while($row = mysqli_fetch_array($network_sql)){
+        $response['network'][] = $row;
+    }
+
+    $locations_sql = mysqli_query($mysqli, "SELECT location_id, location_name FROM locations
+  WHERE location_client_id = '$client_id'
+  AND company_id = '$session_company_id'");
+    while($row = mysqli_fetch_array($locations_sql)){
+        $response['locations'][] = $row;
+    }
+
+    echo json_encode($response);
+}
+
 if(isset($_GET['delete_network'])){
     $network_id = intval($_GET['delete_network']);
 


### PR DESCRIPTION
As per our recent chat, this serves as a proof of concept of only pulling part of the data from the database on the main page and, instead, showing the rest once the edit modal is displayed dynamically with AJAX.

My dev site page has three networks with a load of roughly 0.0040s. With these changes, that decreases to 0.002s. Whilst you probably wouldn't notice the difference on the networks page specifically, you probably would notice this for tickets or assets where much more information is being retrieved.