### PR TITLE
Show OS if asset is a switch/router/fw

### DIFF
--- a/client_asset_edit_modal.php
+++ b/client_asset_edit_modal.php
@@ -95,7 +95,7 @@
               </div>
               <?php } ?>
 
-              <?php if($asset_type !== 'Phone' AND $asset_type !== 'Mobile Phone' AND $asset_type !== 'Tablet' AND $asset_type !== 'Firewall/Router' AND $asset_type !== 'Switch' AND $asset_type !== 'Access Point' AND $asset_type !== 'Printer' AND $asset_type !== 'Camera' AND $asset_type !== 'TV' AND $asset_type !== 'Other'){ ?>
+              <?php if($asset_type !== 'Phone' AND $asset_type !== 'Mobile Phone' AND $asset_type !== 'Tablet' AND $asset_type !== 'Access Point' AND $asset_type !== 'Printer' AND $asset_type !== 'Camera' AND $asset_type !== 'TV' AND $asset_type !== 'Other'){ ?>
               <div class="form-group">
                 <label>Operating System</label>
                 <div class="input-group">


### PR DESCRIPTION
I think that Switches, Routers, and Firewalls should still show the asset OS field. E.g. Cisco IOS