### PR TITLE
Ticketing updates

### DIFF
--- a/client_tickets.php
+++ b/client_tickets.php
@@ -113,11 +113,16 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
             $ticket_status = $row['ticket_status'];
             $ticket_created_at = $row['ticket_created_at'];
             $ticket_updated_at = $row['ticket_updated_at'];
-            if(empty($ticket_updated_at)){
-              $ticket_updated_at_display = "<p class='text-danger'>Never</p>";
-            }else{
-              $ticket_updated_at_display = $ticket_updated_at;
-            }
+              if (empty($ticket_updated_at)) {
+                  if($ticket_status == "Closed"){
+                      $ticket_updated_at_display = "<p>Never</p>";
+                  }
+                  else{
+                      $ticket_updated_at_display = "<p class='text-danger'>Never</p>";
+                  }
+              } else {
+                  $ticket_updated_at_display = $ticket_updated_at;
+              }
             $ticket_closed_at = $row['ticket_closed_at'];
             
             if($ticket_status == "Open"){
@@ -137,12 +142,17 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
             }else{
               $ticket_priority_display = "-";
             }
-            $ticket_assigned_to = $row['ticket_assigned_to'];
-            if(empty($ticket_assigned_to)){
-              $ticket_assigned_to_display = "<p class='text-danger'>Not Assigned</p>";
-            }else{
-              $ticket_assigned_to_display = $row['user_name'];
-            }
+              $ticket_assigned_to = $row['ticket_assigned_to'];
+              if (empty($ticket_assigned_to)) {
+                  if($ticket_status == "Closed"){
+                      $ticket_assigned_to_display = "<p>Not Assigned</p>";
+                  }
+                  else{
+                      $ticket_assigned_to_display = "<p class='text-danger'>Not Assigned</p>";
+                  }
+              } else {
+                  $ticket_assigned_to_display = $row['user_name'];
+              }
             $contact_id = $row['contact_id'];
             $contact_name = $row['contact_name'];
             if(empty($contact_name)){

--- a/db.sql
+++ b/db.sql
@@ -1281,7 +1281,7 @@ CREATE TABLE `tickets` (
   `ticket_archived_at` datetime DEFAULT NULL,
   `ticket_closed_at` datetime DEFAULT NULL,
   `ticket_created_by` int(11) NOT NULL,
-  `ticket_assigned_to` int(11) DEFAULT NULL,
+  `ticket_assigned_to` int(11) NOT NULL DEFAULT '0',
   `ticket_closed_by` int(11) DEFAULT NULL,
   `ticket_vendor_id` int(11) DEFAULT NULL,
   `ticket_client_id` int(11) DEFAULT NULL,

--- a/ticket.php
+++ b/ticket.php
@@ -477,7 +477,7 @@ if(isset($_GET['ticket_id'])){
 
     <div class="card card-body card-outline card-dark mb-2">
      <div class="">
-        <a href="#" class="btn btn-outline-success btn-block">INVOICE</a>
+<!--        <a href="#" class="btn btn-outline-success btn-block">INVOICE</a>-->
         <a href="post.php?close_ticket=<?php echo $ticket_id; ?>" class="btn btn-outline-danger btn-block">CLOSE TICKET</a>
       </div>
     </div>

--- a/ticket.php
+++ b/ticket.php
@@ -103,18 +103,18 @@ if(isset($_GET['ticket_id'])){
     $ticket_assigned_to_display = $row['user_name'];
   }
 
-  if($contact_id == $primary_contact){
-     $primary_contact_display = "<small class='text-success'>Primary Contact</small>";
-  }else{
-    $primary_contact_display = "<small class='text-danger'>Needs approval</small>";
-  }
+//  if($contact_id == $primary_contact){
+//     $primary_contact_display = "<small class='text-success'>Primary Contact</small>";
+//  }else{
+//    $primary_contact_display = "<small class='text-danger'>Needs approval</small>";
+//  }
     
   //Get Contact Ticket Stats
-  $ticket_related_open = mysqli_query($mysqli,"SELECT COUNT(ticket_id) AS ticket_related_open FROM tickets WHERE ticket_status = 'open' AND ticket_contact_id = $contact_id ");
+  $ticket_related_open = mysqli_query($mysqli,"SELECT COUNT(ticket_id) AS ticket_related_open FROM tickets WHERE ticket_status != 'Closed' AND ticket_contact_id = $contact_id ");
   $row = mysqli_fetch_array($ticket_related_open);
   $ticket_related_open = $row['ticket_related_open'];
   
-  $ticket_related_closed = mysqli_query($mysqli,"SELECT COUNT(ticket_id) AS ticket_related_closed  FROM tickets WHERE ticket_status = 'closed' AND ticket_contact_id = $contact_id ");
+  $ticket_related_closed = mysqli_query($mysqli,"SELECT COUNT(ticket_id) AS ticket_related_closed  FROM tickets WHERE ticket_status = 'Closed' AND ticket_contact_id = $contact_id ");
   $row = mysqli_fetch_array($ticket_related_closed);
   $ticket_related_closed = $row['ticket_related_closed'];
   
@@ -346,8 +346,8 @@ if(isset($_GET['ticket_id'])){
         <h4 class="text-secondary">Contact</h4>
         <i class="fa fa-fw fa-user text-secondary ml-1 mr-2 mb-2"></i><strong><?php echo $contact_name; ?></strong>
         <br>
-        <i class="fa fa-fw fa-info-circle text-secondary ml-1 mr-2 mb-2"></i><?php echo $primary_contact_display; ?>
-        <br>
+<!--        <i class="fa fa-fw fa-info-circle text-secondary ml-1 mr-2 mb-2"></i>--><?php //echo $primary_contact_display; ?>
+<!--        <br>-->
         <i class="fa fa-fw fa-envelope text-secondary ml-1 mr-2 mb-2"></i>Related tickets: Open <strong><?php echo $ticket_related_open; ?></strong> | Closed <strong><?php echo $ticket_related_closed; ?></strong> | Total <strong><?php echo $ticket_related_total; ?></strong>  
         <hr>
         <?php

--- a/ticket_add_modal.php
+++ b/ticket_add_modal.php
@@ -67,7 +67,7 @@
                 <span class="input-group-text"><i class="fa fa-fw fa-user"></i></span>
               </div>
               <select class="form-control select2" name="assigned_to">
-                <option value="">Not Assigned</option>
+                <option value="0">Not Assigned</option>
                 <?php 
                 
                 $sql = mysqli_query($mysqli,"SELECT * FROM users, user_companies WHERE users.user_id = user_companies.user_id AND user_companies.company_id = $session_company_id ORDER BY user_name ASC");

--- a/ticket_edit_modal.php
+++ b/ticket_edit_modal.php
@@ -18,7 +18,7 @@
                 <span class="input-group-text"><i class="fa fa-fw fa-user"></i></span>
               </div>
               <select class="form-control select2" name="assigned_to">
-                <option value="">Not Assigned</option>
+                <option value="0">Not Assigned</option>
                 <?php 
                 
                 $sql_assign_to_select = mysqli_query($mysqli,"SELECT * FROM users, user_companies WHERE users.user_id = user_companies.user_id AND user_companies.company_id = $session_company_id ORDER BY user_name ASC");


### PR DESCRIPTION
- Change database ticket_assigned_to to be NOT NULL and default to 0 to allow for search/filtering of unassigned tickets. Currently, unassigned tickets can be both assigned to NULL / 0.
- Comment unused/non-working elements (primary contact approval, tasks,)
- Fix ticket counters not taking into account "Working" or "On hold" tickets
- Implement "My tickets" logic - can see agent active/closed tickets
- Add filter for "Assigned to" on main ticket view
- Only show not assigned / never last response in red if the ticket is still active