### PR TITLE
Update how functions.php gets the remote IP address for logging

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -83,7 +83,7 @@ function getIP() {
 
     // Allow overrides via config.php in-case we use a proxy - https://docs.itflow.org/config_php
     if (defined("CONST_GET_IP_METHOD") && CONST_GET_IP_METHOD == "HTTP_X_FORWARDED_FOR") {
-        $ip = explode(',', getenv('HTTP_X_FORWARDED_FOR'))[0] ?? $_SERVER['REMOTE_ADDR'];;
+        $ip = explode(',', getenv('HTTP_X_FORWARDED_FOR'))[0] ?? $_SERVER['REMOTE_ADDR'];
     } elseif (defined("CONST_GET_IP_METHOD") && CONST_GET_IP_METHOD == "HTTP_CF_CONNECTING_IP") {
         $ip = $_SERVER["HTTP_CF_CONNECTING_IP"] ?? $_SERVER['REMOTE_ADDR'];
     }


### PR DESCRIPTION
- Builds on PR #1210 to always get the leftmost IP address
- Cloudflare (HTTP_CF_CONNECTING_IP) must now be explicitly defined, otherwise people could add the HTTP_CF_CONNECTING_IP header to a non-Cloudflare host and spoof IPs
- Tidy up the if/else logic a little