### PR TITLE
setup.php fix

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -554,7 +554,7 @@ CREATE TABLE `companies` (
   `company_website` varchar(200) DEFAULT NULL,
   `company_logo` varchar(250) DEFAULT NULL,
   `company_locale` varchar(200) DEFAULT NULL,
-  `company_currency` varchar(200) DEFAULT 'USD',
+  `company_currency` varchar(200) NOT NULL DEFAULT 'USD',
   `company_tax_id` varchar(200) DEFAULT NULL,
   `company_created_at` datetime NOT NULL DEFAULT current_timestamp(),
   `company_updated_at` datetime DEFAULT NULL ON UPDATE current_timestamp(),

--- a/includes/inc_set_timezone.php
+++ b/includes/inc_set_timezone.php
@@ -2,7 +2,14 @@
 
 $result = mysqli_query($mysqli, "SELECT config_timezone FROM settings WHERE company_id = 1");
 $row = mysqli_fetch_array($result);
-$_SESSION['session_timezone'] = $row['config_timezone'];
+$config_timezone = trim($row['config_timezone'] ?? '');
+
+// Fallback naar geldige tijdzone als deze leeg of ongeldig is
+if (empty($config_timezone) || !in_array($config_timezone, timezone_identifiers_list())) {
+    $config_timezone = 'Europe/Brussels';
+}
+
+$_SESSION['session_timezone'] = $config_timezone;
 
 // Set PHP timezone
 date_default_timezone_set($_SESSION['session_timezone']);


### PR DESCRIPTION
fixed mandatory currency and date setting, those are checked at the first page and you can only select them on the second page and that cause a 500 error on CWP

hard coded now the currency in the SQL file and the timezone in the PHP file so they wont be empty