### PR TITLE
Add full Microsoft 365 and Google OAuth mail support

### DIFF
--- a/admin/oauth_microsoft_mail_callback.php
+++ b/admin/oauth_microsoft_mail_callback.php
@@ -1,0 +1,101 @@
+<?php
+
+require_once "../config.php";
+require_once "../functions.php";
+require_once "../includes/check_login.php";
+
+if (!isset($session_is_admin) || !$session_is_admin) {
+    flash_alert("Admin access required.", 'error');
+    redirect('/admin/settings_mail.php');
+}
+
+$state = sanitizeInput($_GET['state'] ?? '');
+$code = $_GET['code'] ?? '';
+$error = sanitizeInput($_GET['error'] ?? '');
+$error_description = sanitizeInput($_GET['error_description'] ?? '');
+
+$session_state = $_SESSION['mail_oauth_state'] ?? '';
+$session_state_expires = intval($_SESSION['mail_oauth_state_expires_at'] ?? 0);
+
+unset($_SESSION['mail_oauth_state'], $_SESSION['mail_oauth_state_expires_at']);
+
+if (!empty($error)) {
+    $msg = "Microsoft OAuth authorization failed: $error";
+    if (!empty($error_description)) {
+        $msg .= " ($error_description)";
+    }
+
+    flash_alert($msg, 'error');
+    redirect('/admin/settings_mail.php');
+}
+
+if (empty($state) || empty($code) || empty($session_state) || !hash_equals($session_state, $state) || time() > $session_state_expires) {
+    flash_alert("Microsoft OAuth callback validation failed. Please try connecting again.", 'error');
+    redirect('/admin/settings_mail.php');
+}
+
+if (empty($config_mail_oauth_client_id) || empty($config_mail_oauth_client_secret) || empty($config_mail_oauth_tenant_id)) {
+    flash_alert("Microsoft OAuth settings are incomplete. Please fill Client ID, Client Secret, and Tenant ID.", 'error');
+    redirect('/admin/settings_mail.php');
+}
+
+if (defined('BASE_URL') && !empty(BASE_URL)) {
+    $base_url = rtrim((string) BASE_URL, '/');
+} else {
+    $base_url = 'https://' . rtrim((string) $config_base_url, '/');
+}
+
+$redirect_uri = $base_url . '/admin/oauth_microsoft_mail_callback.php';
+$token_url = 'https://login.microsoftonline.com/' . rawurlencode($config_mail_oauth_tenant_id) . '/oauth2/v2.0/token';
+$scope = 'offline_access openid profile https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send';
+
+$ch = curl_init($token_url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+    'client_id' => $config_mail_oauth_client_id,
+    'client_secret' => $config_mail_oauth_client_secret,
+    'grant_type' => 'authorization_code',
+    'code' => $code,
+    'redirect_uri' => $redirect_uri,
+    'scope' => $scope,
+], '', '&'));
+curl_setopt($ch, CURLOPT_TIMEOUT, 20);
+
+$raw_body = curl_exec($ch);
+$curl_err = curl_error($ch);
+$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+if ($raw_body === false || $http_code < 200 || $http_code >= 300) {
+    $reason = !empty($curl_err) ? $curl_err : "HTTP $http_code";
+    flash_alert("Microsoft OAuth token exchange failed: $reason", 'error');
+    redirect('/admin/settings_mail.php');
+}
+
+$json = json_decode($raw_body, true);
+if (!is_array($json) || empty($json['refresh_token']) || empty($json['access_token'])) {
+    flash_alert("Microsoft OAuth token exchange failed: refresh token or access token missing.", 'error');
+    redirect('/admin/settings_mail.php');
+}
+
+$refresh_token = (string) $json['refresh_token'];
+$access_token = (string) $json['access_token'];
+$expires_at = date('Y-m-d H:i:s', time() + (int)($json['expires_in'] ?? 3600));
+
+$refresh_token_esc = mysqli_real_escape_string($mysqli, $refresh_token);
+$access_token_esc = mysqli_real_escape_string($mysqli, $access_token);
+$expires_at_esc = mysqli_real_escape_string($mysqli, $expires_at);
+
+mysqli_query($mysqli, "UPDATE settings SET
+    config_imap_provider = 'microsoft_oauth',
+    config_smtp_provider = 'microsoft_oauth',
+    config_mail_oauth_refresh_token = '$refresh_token_esc',
+    config_mail_oauth_access_token = '$access_token_esc',
+    config_mail_oauth_access_token_expires_at = '$expires_at_esc'
+    WHERE company_id = 1
+");
+
+logAction("Settings", "Edit", "$session_name completed Microsoft OAuth connect flow for mail settings");
+flash_alert("Microsoft OAuth connected successfully. Token expires at $expires_at.");
+redirect('/admin/settings_mail.php');

--- a/admin/post/settings_mail.php
+++ b/admin/post/settings_mail.php
@@ -2,6 +2,75 @@
 
 defined('FROM_POST_HANDLER') || die("Direct file access is not allowed");
 
+if (isset($_POST['oauth_connect_microsoft_mail'])) {
+
+    validateCSRFToken($_POST['csrf_token']);
+
+    // Save current IMAP/OAuth form values first so auth flow always uses latest inputs.
+    $config_imap_provider = sanitizeInput($_POST['config_imap_provider'] ?? '');
+    $config_imap_username = sanitizeInput($_POST['config_imap_username'] ?? '');
+    $config_mail_oauth_client_id = sanitizeInput($_POST['config_mail_oauth_client_id'] ?? '');
+    $config_mail_oauth_client_secret = sanitizeInput($_POST['config_mail_oauth_client_secret'] ?? '');
+    $config_mail_oauth_tenant_id = sanitizeInput($_POST['config_mail_oauth_tenant_id'] ?? '');
+    $config_mail_oauth_refresh_token = sanitizeInput($_POST['config_mail_oauth_refresh_token'] ?? '');
+    $config_mail_oauth_access_token = sanitizeInput($_POST['config_mail_oauth_access_token'] ?? '');
+
+    mysqli_query($mysqli, "UPDATE settings SET
+        config_imap_provider = '$config_imap_provider',
+        config_imap_username = '$config_imap_username',
+        config_mail_oauth_client_id = '$config_mail_oauth_client_id',
+        config_mail_oauth_client_secret = '$config_mail_oauth_client_secret',
+        config_mail_oauth_tenant_id = '$config_mail_oauth_tenant_id',
+        config_mail_oauth_refresh_token = '$config_mail_oauth_refresh_token',
+        config_mail_oauth_access_token = '$config_mail_oauth_access_token'
+        WHERE company_id = 1
+    ");
+
+    if ($config_imap_provider !== 'microsoft_oauth') {
+        flash_alert("Please set IMAP Provider to Microsoft 365 (OAuth) before connecting.", 'error');
+        redirect();
+    }
+
+    if (empty($config_mail_oauth_client_id) || empty($config_mail_oauth_client_secret) || empty($config_mail_oauth_tenant_id)) {
+        flash_alert("Missing Microsoft OAuth settings. Please provide Client ID, Client Secret, and Tenant ID first.", 'error');
+        redirect();
+    }
+
+    if (defined('BASE_URL') && !empty(BASE_URL)) {
+        $base_url = rtrim((string) BASE_URL, '/');
+    } else {
+        $base_url = 'https://' . rtrim((string) $config_base_url, '/');
+    }
+
+    $redirect_uri = $base_url . '/admin/oauth_microsoft_mail_callback.php';
+
+    try {
+        $state = bin2hex(random_bytes(32));
+    } catch (Throwable $e) {
+        $state = sha1(uniqid((string) mt_rand(), true));
+    }
+
+    $_SESSION['mail_oauth_state'] = $state;
+    $_SESSION['mail_oauth_state_expires_at'] = time() + 600;
+
+    $scope = 'offline_access openid profile https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send';
+
+    $authorize_url = 'https://login.microsoftonline.com/' . rawurlencode($config_mail_oauth_tenant_id) . '/oauth2/v2.0/authorize?'
+        . http_build_query([
+            'client_id' => $config_mail_oauth_client_id,
+            'response_type' => 'code',
+            'redirect_uri' => $redirect_uri,
+            'response_mode' => 'query',
+            'scope' => $scope,
+            'state' => $state,
+            'prompt' => 'consent',
+        ], '', '&', PHP_QUERY_RFC3986);
+
+    logAction("Settings", "Edit", "$session_name started Microsoft OAuth connect flow for mail settings");
+
+    redirect($authorize_url);
+}
+
 if (isset($_POST['edit_mail_smtp_settings'])) {
     
     validateCSRFToken($_POST['csrf_token']);
@@ -163,11 +232,144 @@ if (isset($_POST['test_email_imap'])) {
 
     validateCSRFToken($_POST['csrf_token']);
 
+    $provider = sanitizeInput($config_imap_provider ?? '');
+
     $host       = $config_imap_host;
     $port       = (int) $config_imap_port;
     $encryption = strtolower(trim($config_imap_encryption)); // e.g. "ssl", "tls", "none"
     $username   = $config_imap_username;
     $password   = $config_imap_password;
+
+    // Shared OAuth fields
+    $config_mail_oauth_client_id               = $config_mail_oauth_client_id ?? '';
+    $config_mail_oauth_client_secret           = $config_mail_oauth_client_secret ?? '';
+    $config_mail_oauth_tenant_id               = $config_mail_oauth_tenant_id ?? '';
+    $config_mail_oauth_refresh_token           = $config_mail_oauth_refresh_token ?? '';
+    $config_mail_oauth_access_token            = $config_mail_oauth_access_token ?? '';
+    $config_mail_oauth_access_token_expires_at = $config_mail_oauth_access_token_expires_at ?? '';
+
+    $is_oauth = ($provider === 'google_oauth' || $provider === 'microsoft_oauth');
+
+    if ($provider === 'google_oauth') {
+        if (empty($host)) {
+            $host = 'imap.gmail.com';
+        }
+        if (empty($port)) {
+            $port = 993;
+        }
+        if (empty($encryption)) {
+            $encryption = 'ssl';
+        }
+    } elseif ($provider === 'microsoft_oauth') {
+        if (empty($host)) {
+            $host = 'outlook.office365.com';
+        }
+        if (empty($port)) {
+            $port = 993;
+        }
+        if (empty($encryption)) {
+            $encryption = 'ssl';
+        }
+    }
+
+    if (empty($host) || empty($port) || empty($username)) {
+        flash_alert("<strong>IMAP connection failed:</strong> Missing host, port, or username.", 'error');
+        redirect();
+    }
+
+    $token_is_expired = function (?string $expires_at): bool {
+        if (empty($expires_at)) {
+            return true;
+        }
+
+        $ts = strtotime($expires_at);
+
+        if ($ts === false) {
+            return true;
+        }
+
+        return ($ts - 60) <= time();
+    };
+
+    $http_form_post = function (string $url, array $fields): array {
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($fields, '', '&'));
+        curl_setopt($ch, CURLOPT_TIMEOUT, 20);
+
+        $raw = curl_exec($ch);
+        $err = curl_error($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        curl_close($ch);
+
+        return [
+            'ok' => ($raw !== false && $code >= 200 && $code < 300),
+            'body' => $raw,
+            'code' => $code,
+            'err' => $err,
+        ];
+    };
+
+    if ($is_oauth) {
+        if (!empty($config_mail_oauth_access_token) && !$token_is_expired($config_mail_oauth_access_token_expires_at)) {
+            $password = $config_mail_oauth_access_token;
+        } else {
+            if (empty($config_mail_oauth_client_id) || empty($config_mail_oauth_client_secret) || empty($config_mail_oauth_refresh_token)) {
+                flash_alert("<strong>IMAP OAuth failed:</strong> Missing OAuth client credentials or refresh token.", 'error');
+                redirect();
+            }
+
+            if ($provider === 'google_oauth') {
+                $response = $http_form_post('https://oauth2.googleapis.com/token', [
+                    'client_id' => $config_mail_oauth_client_id,
+                    'client_secret' => $config_mail_oauth_client_secret,
+                    'refresh_token' => $config_mail_oauth_refresh_token,
+                    'grant_type' => 'refresh_token',
+                ]);
+            } else {
+                if (empty($config_mail_oauth_tenant_id)) {
+                    flash_alert("<strong>IMAP OAuth failed:</strong> Microsoft tenant ID is required.", 'error');
+                    redirect();
+                }
+
+                $token_url = "https://login.microsoftonline.com/" . rawurlencode($config_mail_oauth_tenant_id) . "/oauth2/v2.0/token";
+                $response = $http_form_post($token_url, [
+                    'client_id' => $config_mail_oauth_client_id,
+                    'client_secret' => $config_mail_oauth_client_secret,
+                    'refresh_token' => $config_mail_oauth_refresh_token,
+                    'grant_type' => 'refresh_token',
+                ]);
+            }
+
+            if (!$response['ok']) {
+                flash_alert("<strong>IMAP OAuth failed:</strong> Could not refresh access token.", 'error');
+                redirect();
+            }
+
+            $json = json_decode($response['body'], true);
+            if (!is_array($json) || empty($json['access_token'])) {
+                flash_alert("<strong>IMAP OAuth failed:</strong> Token response did not include an access token.", 'error');
+                redirect();
+            }
+
+            $password = $json['access_token'];
+            $expires_at = date('Y-m-d H:i:s', time() + (int)($json['expires_in'] ?? 3600));
+            $refresh_token_to_save = $json['refresh_token'] ?? null;
+
+            $token_esc = mysqli_real_escape_string($mysqli, $password);
+            $expires_at_esc = mysqli_real_escape_string($mysqli, $expires_at);
+
+            $refresh_sql = '';
+            if (!empty($refresh_token_to_save)) {
+                $refresh_token_esc = mysqli_real_escape_string($mysqli, $refresh_token_to_save);
+                $refresh_sql = ", config_mail_oauth_refresh_token = '{$refresh_token_esc}'";
+            }
+
+            mysqli_query($mysqli, "UPDATE settings SET config_mail_oauth_access_token = '{$token_esc}', config_mail_oauth_access_token_expires_at = '{$expires_at_esc}'{$refresh_sql} WHERE company_id = 1");
+        }
+    }
 
     // Build remote socket (implicit SSL vs plain TCP)
     $transport = 'tcp';
@@ -178,19 +380,19 @@ if (isset($_POST['test_email_imap'])) {
     $remote_socket = $transport . '://' . $host . ':' . $port;
 
     // Stream context (you can tighten these if you want strict validation)
-    $contextOptions = [];
+    $context_options = [];
     if (in_array($encryption, ['ssl', 'tls'], true)) {
-        $contextOptions['ssl'] = [
-            'verify_peer'       => false,
-            'verify_peer_name'  => false,
+        $context_options['ssl'] = [
+            'verify_peer' => false,
+            'verify_peer_name' => false,
             'allow_self_signed' => true,
         ];
     }
 
-    $context = stream_context_create($contextOptions);
+    $context = stream_context_create($context_options);
 
     try {
-        $errno  = 0;
+        $errno = 0;
         $errstr = '';
 
         // 10-second timeout, adjust as needed
@@ -215,10 +417,8 @@ if (isset($_POST['test_email_imap'])) {
             fclose($fp);
             throw new Exception("Invalid IMAP greeting: " . trim((string) $greeting));
         }
-
         // If you really want STARTTLS for "tls" (port 143), you can do it here
         if ($encryption === 'tls' && stripos($greeting, 'STARTTLS') !== false) {
-            // Request STARTTLS
             fwrite($fp, "A0001 STARTTLS\r\n");
             $line = fgets($fp, 1024);
             if ($line === false || stripos($line, 'A0001 OK') !== 0) {
@@ -226,28 +426,31 @@ if (isset($_POST['test_email_imap'])) {
                 throw new Exception("STARTTLS failed: " . trim((string) $line));
             }
 
-            // Enable crypto on the stream
             if (!stream_socket_enable_crypto($fp, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
                 fclose($fp);
                 throw new Exception("Unable to enable TLS encryption on IMAP connection.");
             }
         }
 
-        // --- Do LOGIN command ---
         $tag = 'A0002';
 
-        // Simple quoting; this may fail with some special chars in username/password.
-        $loginCmd = sprintf(
-            "%s LOGIN \"%s\" \"%s\"\r\n",
-            $tag,
-            addcslashes($username, "\\\""),
-            addcslashes($password, "\\\"")
-        );
+        if ($is_oauth) {
+            $oauth_b64 = base64_encode("user={$username}\x01auth=Bearer {$password}\x01\x01");
+            $auth_cmd = sprintf("%s AUTHENTICATE XOAUTH2 %s\r\n", $tag, $oauth_b64);
+            fwrite($fp, $auth_cmd);
+        } else {
+            $login_cmd = sprintf(
+                "%s LOGIN \"%s\" \"%s\"\r\n",
+                $tag,
+                addcslashes($username, "\\\""),
+                addcslashes($password, "\\\"")
+            );
 
-        fwrite($fp, $loginCmd);
+            fwrite($fp, $login_cmd);
+        }
 
-        $success   = false;
-        $errorLine = '';
+        $success = false;
+        $error_line = '';
 
         while (!feof($fp)) {
             $line = fgets($fp, 2048);
@@ -255,12 +458,11 @@ if (isset($_POST['test_email_imap'])) {
                 break;
             }
 
-            // Look for tagged response for our LOGIN
             if (strpos($line, $tag . ' ') === 0) {
                 if (stripos($line, $tag . ' OK') === 0) {
                     $success = true;
                 } else {
-                    $errorLine = trim($line);
+                    $error_line = trim($line);
                 }
                 break;
             }
@@ -271,17 +473,106 @@ if (isset($_POST['test_email_imap'])) {
         fclose($fp);
 
         if ($success) {
-            flash_alert("Connected successfully");
-        } else {
-            if (!$errorLine) {
-                $errorLine = 'Unknown IMAP authentication error';
+            if ($is_oauth) {
+                flash_alert("Connected successfully using OAuth");
+            } else {
+                flash_alert("Connected successfully");
             }
-            throw new Exception($errorLine);
+        } else {
+            if (!$error_line) {
+                $error_line = 'Unknown IMAP authentication error';
+            }
+            throw new Exception($error_line);
         }
 
     } catch (Exception $e) {
         flash_alert("<strong>IMAP connection failed:</strong> " . htmlspecialchars($e->getMessage()), 'error');
     }
 
+    redirect();
+}
+
+
+if (isset($_POST['test_oauth_token_refresh'])) {
+
+    validateCSRFToken($_POST['csrf_token']);
+
+    $provider = sanitizeInput($_POST['oauth_provider'] ?? '');
+
+    if ($provider !== 'google_oauth' && $provider !== 'microsoft_oauth') {
+        flash_alert("OAuth token test failed: unsupported provider.", 'error');
+        redirect();
+    }
+
+    $oauth_client_id = sanitizeInput($config_mail_oauth_client_id ?? '');
+    $oauth_client_secret = sanitizeInput($config_mail_oauth_client_secret ?? '');
+    $oauth_tenant_id = sanitizeInput($config_mail_oauth_tenant_id ?? '');
+    $oauth_refresh_token = sanitizeInput($config_mail_oauth_refresh_token ?? '');
+
+    if (empty($oauth_client_id) || empty($oauth_client_secret) || empty($oauth_refresh_token)) {
+        flash_alert("OAuth token test failed: missing client ID, client secret, or refresh token.", 'error');
+        redirect();
+    }
+
+    if ($provider === 'microsoft_oauth' && empty($oauth_tenant_id)) {
+        flash_alert("OAuth token test failed: Microsoft tenant ID is required.", 'error');
+        redirect();
+    }
+
+    $token_url = 'https://oauth2.googleapis.com/token';
+    if ($provider === 'microsoft_oauth') {
+        $token_url = "https://login.microsoftonline.com/" . rawurlencode($oauth_tenant_id) . "/oauth2/v2.0/token";
+    }
+
+    $post_fields = http_build_query([
+        'client_id' => $oauth_client_id,
+        'client_secret' => $oauth_client_secret,
+        'refresh_token' => $oauth_refresh_token,
+        'grant_type' => 'refresh_token',
+    ]);
+
+    $ch = curl_init($token_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $post_fields);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 20);
+
+    $raw_body = curl_exec($ch);
+    $curl_err = curl_error($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($raw_body === false || $http_code < 200 || $http_code >= 300) {
+        $err_msg = !empty($curl_err) ? $curl_err : "HTTP $http_code";
+        flash_alert("OAuth token test failed: $err_msg", 'error');
+        redirect();
+    }
+
+    $json = json_decode($raw_body, true);
+
+    if (!is_array($json) || empty($json['access_token'])) {
+        flash_alert("OAuth token test failed: access token missing in provider response.", 'error');
+        redirect();
+    }
+
+    $new_access_token = sanitizeInput($json['access_token']);
+    $new_expires_at = date('Y-m-d H:i:s', time() + (int)($json['expires_in'] ?? 3600));
+    $new_refresh_token = !empty($json['refresh_token']) ? sanitizeInput($json['refresh_token']) : '';
+
+    $new_access_token_esc = mysqli_real_escape_string($mysqli, $new_access_token);
+    $new_expires_at_esc = mysqli_real_escape_string($mysqli, $new_expires_at);
+
+    $refresh_sql = '';
+    if (!empty($new_refresh_token)) {
+        $new_refresh_token_esc = mysqli_real_escape_string($mysqli, $new_refresh_token);
+        $refresh_sql = ", config_mail_oauth_refresh_token = '$new_refresh_token_esc'";
+    }
+
+    mysqli_query($mysqli, "UPDATE settings SET config_mail_oauth_access_token = '$new_access_token_esc', config_mail_oauth_access_token_expires_at = '$new_expires_at_esc'$refresh_sql WHERE company_id = 1");
+
+    $provider_label = $provider === 'microsoft_oauth' ? 'Microsoft 365' : 'Google Workspace';
+    logAction("Settings", "Edit", "$session_name tested OAuth token refresh for $provider_label mail settings");
+
+    flash_alert("OAuth token refresh successful for $provider_label. Access token expires at $new_expires_at.");
     redirect();
 }

--- a/admin/post/settings_mail.php
+++ b/admin/post/settings_mail.php
@@ -2,6 +2,10 @@
 
 defined('FROM_POST_HANDLER') || die("Direct file access is not allowed");
 
+if (!defined('MICROSOFT_OAUTH_BASE_URL')) {
+    define('MICROSOFT_OAUTH_BASE_URL', 'https://login.microsoftonline.com/');
+}
+
 if (isset($_POST['oauth_connect_microsoft_mail'])) {
 
     validateCSRFToken($_POST['csrf_token']);
@@ -55,7 +59,7 @@ if (isset($_POST['oauth_connect_microsoft_mail'])) {
 
     $scope = 'offline_access openid profile https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send';
 
-    $authorize_url = 'https://login.microsoftonline.com/' . rawurlencode($config_mail_oauth_tenant_id) . '/oauth2/v2.0/authorize?'
+    $authorize_url = MICROSOFT_OAUTH_BASE_URL . rawurlencode($config_mail_oauth_tenant_id) . '/oauth2/v2.0/authorize?'
         . http_build_query([
             'client_id' => $config_mail_oauth_client_id,
             'response_type' => 'code',
@@ -334,7 +338,7 @@ if (isset($_POST['test_email_imap'])) {
                     redirect();
                 }
 
-                $token_url = "https://login.microsoftonline.com/" . rawurlencode($config_mail_oauth_tenant_id) . "/oauth2/v2.0/token";
+                $token_url = MICROSOFT_OAUTH_BASE_URL . rawurlencode($config_mail_oauth_tenant_id) . "/oauth2/v2.0/token";
                 $response = $http_form_post($token_url, [
                     'client_id' => $config_mail_oauth_client_id,
                     'client_secret' => $config_mail_oauth_client_secret,
@@ -521,7 +525,7 @@ if (isset($_POST['test_oauth_token_refresh'])) {
 
     $token_url = 'https://oauth2.googleapis.com/token';
     if ($provider === 'microsoft_oauth') {
-        $token_url = "https://login.microsoftonline.com/" . rawurlencode($oauth_tenant_id) . "/oauth2/v2.0/token";
+        $token_url = MICROSOFT_OAUTH_BASE_URL . rawurlencode($oauth_tenant_id) . "/oauth2/v2.0/token";
     }
 
     $post_fields = http_build_query([

--- a/agent/post/ticket.php
+++ b/agent/post/ticket.php
@@ -107,7 +107,7 @@ if (isset($_POST['add_ticket'])) {
     }
 
     // E-mail client
-    if (!empty($config_smtp_host) && $config_ticket_client_general_notifications == 1) {
+    if ((!empty($config_smtp_host) || !empty($config_smtp_provider)) && $config_ticket_client_general_notifications == 1) {
 
         // Get contact/ticket details
         $sql = mysqli_query($mysqli, "SELECT contact_name, contact_email, ticket_prefix, ticket_number, ticket_category, ticket_subject, ticket_details, ticket_priority, ticket_status, ticket_created_by, ticket_assigned_to, ticket_client_id FROM tickets
@@ -260,7 +260,7 @@ if (isset($_POST['edit_ticket'])) {
     $client_id = intval($row['ticket_client_id']);
 
     // Notify new contact if selected
-    if ($notify && !empty($config_smtp_host)) {
+    if ($notify && (!empty($config_smtp_host) || !empty($config_smtp_provider))) {
 
         // Get Company Name Phone Number and Sanitize for Email Sending
         $sql = mysqli_query($mysqli, "SELECT company_name, company_phone, company_phone_country_code FROM companies WHERE company_id = 1");
@@ -379,7 +379,7 @@ if (isset($_POST['edit_ticket_contact'])) {
     $contact_email = sanitizeInput($row['contact_email']);
 
     // Notify new contact (if selected, valid & configured)
-    if ($notify && filter_var($contact_email, FILTER_VALIDATE_EMAIL) && !empty($config_smtp_host)) {
+    if ($notify && filter_var($contact_email, FILTER_VALIDATE_EMAIL) && (!empty($config_smtp_host) || !empty($config_smtp_provider))) {
 
         // Get Company Phone Number
         $sql = mysqli_query($mysqli, "SELECT company_name, company_phone, company_phone_country_code FROM companies WHERE company_id = 1");
@@ -489,7 +489,7 @@ if (isset($_POST['add_ticket_watcher'])) {
             mysqli_query($mysqli, "INSERT INTO ticket_watchers SET watcher_email = '$watcher_email', watcher_ticket_id = $ticket_id");
 
             // Notify watcher
-            if ($notify && !empty($config_smtp_host)) {
+            if ($notify && (!empty($config_smtp_host) || !empty($config_smtp_provider))) {
 
 
 
@@ -734,7 +734,7 @@ if (isset($_POST['assign_ticket'])) {
         mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Ticket', notification = 'Ticket $ticket_prefix$ticket_number - Subject: $ticket_subject has been assigned to you by $session_name', notification_action = '/agent/ticket.php?ticket_id=$ticket_id$client_uri', notification_client_id = $client_id, notification_user_id = $assigned_to");
 
         // Email Notification
-        if (!empty($config_smtp_host)) {
+        if ((!empty($config_smtp_host) || !empty($config_smtp_provider))) {
 
             // Sanitize Config vars from get_settings.php
             $config_ticket_from_name = sanitizeInput($config_ticket_from_name);
@@ -926,7 +926,7 @@ if (isset($_POST['bulk_assign_ticket'])) {
             mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Ticket', notification = '$ticket_count Tickets have been assigned to you by $session_name', notification_action = 'tickets.php?status=Open&assigned=$assign_to', notification_client_id = $client_id, notification_user_id = $assign_to");
 
             // Agent Email Notification
-            if (!empty($config_smtp_host)) {
+            if ((!empty($config_smtp_host) || !empty($config_smtp_provider))) {
 
                 // Sanitize Config vars from get_settings.php
                 $config_ticket_from_name = sanitizeInput($config_ticket_from_name);
@@ -1173,7 +1173,7 @@ if (isset($_POST['bulk_resolve_tickets'])) {
                 customAction('ticket_resolve', $ticket_id);
 
                 // Client notification email
-                if (!empty($config_smtp_host) && $config_ticket_client_general_notifications == 1 && $private_note == 0) {
+                if ((!empty($config_smtp_host) || !empty($config_smtp_provider)) && $config_ticket_client_general_notifications == 1 && $private_note == 0) {
 
                     // Get Contact details
                     $ticket_sql = mysqli_query($mysqli, "SELECT contact_name, contact_email FROM tickets
@@ -1352,7 +1352,7 @@ if (isset($_POST['bulk_ticket_reply'])) {
             $company_phone = sanitizeInput(formatPhoneNumber($row['company_phone'], $row['company_phone_country_code']));
 
             // Send e-mail to client if public update & email is set up
-            if ($private_note == 0 && !empty($config_smtp_host)) {
+            if ($private_note == 0 && (!empty($config_smtp_host) || !empty($config_smtp_provider))) {
 
                 $subject = "Ticket update - [$ticket_prefix$ticket_number] - $ticket_subject";
                 $body = "<i style=\'color: #808080\'>##- Please type your reply above this line -##</i><br><br>Hello $contact_name,<br><br>Your ticket regarding $ticket_subject has been updated.<br><br>--------------------------------<br>$ticket_reply<br>--------------------------------<br><br>Ticket: $ticket_prefix$ticket_number<br>Subject: $ticket_subject<br>Status: $ticket_status_name<br>Portal: <a href=\'https://$config_base_url/guest/guest_view_ticket.php?ticket_id=$ticket_id&url_key=$url_key\'>View ticket</a><br><br>--<br>$company_name - Support<br>$from_email<br>$company_phone";
@@ -1669,7 +1669,7 @@ if (isset($_POST['add_ticket_reply'])) {
         $company_phone = sanitizeInput(formatPhoneNumber($row['company_phone'], $row['company_phone_country_code']));
 
         // Send e-mail to client if public update & email is set up
-        if ($ticket_reply_type == 'Public' && $send_email == 1 && !empty($config_smtp_host)) {
+        if ($ticket_reply_type == 'Public' && $send_email == 1 && (!empty($config_smtp_host) || !empty($config_smtp_provider))) {
 
             // Slightly different email subject/text depending on if this update set auto-close
 
@@ -1935,7 +1935,7 @@ if (isset($_GET['resolve_ticket'])) {
     customAction('ticket_resolve', $ticket_id);
 
     // Client notification email
-    if (!empty($config_smtp_host) && $config_ticket_client_general_notifications == 1) {
+    if ((!empty($config_smtp_host) || !empty($config_smtp_provider)) && $config_ticket_client_general_notifications == 1) {
 
         // Get details
         $ticket_sql = mysqli_query($mysqli, "SELECT contact_name, contact_email, ticket_prefix, ticket_number, ticket_subject, ticket_status_name, ticket_assigned_to, ticket_url_key, ticket_client_id FROM tickets
@@ -2032,7 +2032,7 @@ if (isset($_GET['close_ticket'])) {
     customAction('ticket_close', $ticket_id);
 
     // Client notification email
-    if (!empty($config_smtp_host) && $config_ticket_client_general_notifications == 1) {
+    if ((!empty($config_smtp_host) || !empty($config_smtp_provider)) && $config_ticket_client_general_notifications == 1) {
 
         // Get details
         $ticket_sql = mysqli_query($mysqli, "SELECT contact_name, contact_email, ticket_prefix, ticket_number, ticket_subject, ticket_url_key FROM tickets

--- a/agent/post/ticket.php
+++ b/agent/post/ticket.php
@@ -734,7 +734,7 @@ if (isset($_POST['assign_ticket'])) {
         mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Ticket', notification = 'Ticket $ticket_prefix$ticket_number - Subject: $ticket_subject has been assigned to you by $session_name', notification_action = '/agent/ticket.php?ticket_id=$ticket_id$client_uri', notification_client_id = $client_id, notification_user_id = $assigned_to");
 
         // Email Notification
-        if ((!empty($config_smtp_host) || !empty($config_smtp_provider))) {
+        if (!empty($config_smtp_host) || !empty($config_smtp_provider)) {
 
             // Sanitize Config vars from get_settings.php
             $config_ticket_from_name = sanitizeInput($config_ticket_from_name);
@@ -926,7 +926,7 @@ if (isset($_POST['bulk_assign_ticket'])) {
             mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Ticket', notification = '$ticket_count Tickets have been assigned to you by $session_name', notification_action = 'tickets.php?status=Open&assigned=$assign_to', notification_client_id = $client_id, notification_user_id = $assign_to");
 
             // Agent Email Notification
-            if ((!empty($config_smtp_host) || !empty($config_smtp_provider))) {
+            if (!empty($config_smtp_host) || !empty($config_smtp_provider)) {
 
                 // Sanitize Config vars from get_settings.php
                 $config_ticket_from_name = sanitizeInput($config_ticket_from_name);

--- a/agent/ticket.php
+++ b/agent/ticket.php
@@ -48,7 +48,7 @@ if (isset($_GET['ticket_id'])) {
         require_once "../includes/footer.php";
     } else {
 
-        $row = mysqli_fetch_assoc($sql);
+        $row = mysqli_fetch_array($sql);
         $client_id = intval($row['client_id']);
         $client_name = nullable_htmlentities($row['client_name']);
         $client_type = nullable_htmlentities($row['client_type']);
@@ -80,11 +80,11 @@ if (isset($_GET['ticket_id'])) {
 
         //Set Ticket Badge Color based of priority
         if ($ticket_priority == "High") {
-            $ticket_priority_display = "<span class='p-2 badge badge-pill badge-danger'>$ticket_priority</span>";
+            $ticket_priority_display = "<span class='p-2 badge badge-danger'>$ticket_priority</span>";
         } elseif ($ticket_priority == "Medium") {
-            $ticket_priority_display = "<span class='p-2 badge badge-pill badge-warning'>$ticket_priority</span>";
+            $ticket_priority_display = "<span class='p-2 badge badge-warning'>$ticket_priority</span>";
         } elseif ($ticket_priority == "Low") {
-            $ticket_priority_display = "<span class='p-2 badge badge-pill badge-info'>$ticket_priority</span>";
+            $ticket_priority_display = "<span class='p-2 badge badge-info'>$ticket_priority</span>";
         } else {
             $ticket_priority_display = "";
         }
@@ -113,7 +113,7 @@ if (isset($_GET['ticket_id'])) {
 
         $ticket_assigned_to = intval($row['ticket_assigned_to']);
         if (empty($ticket_assigned_to)) {
-            $ticket_assigned_to_display = "<span class='badge badge-pill badge-light'>Unassigned</span>";
+            $ticket_assigned_to_display = "<span class='text-danger text-bold'>Not Assigned</span>";
         } else {
             $ticket_assigned_to_display = nullable_htmlentities($row['user_name']);
         }
@@ -149,8 +149,7 @@ if (isset($_GET['ticket_id'])) {
         $vendor_description = nullable_htmlentities($row['vendor_description']);
         $vendor_account_number = nullable_htmlentities($row['vendor_account_number']);
         $vendor_contact_name = nullable_htmlentities($row['vendor_contact_name']);
-        $vendor_phone_country_code = nullable_htmlentities($row['vendor_phone_country_code']);
-        $vendor_phone = nullable_htmlentities(formatPhoneNumber($row['vendor_phone'], $vendor_phone_country_code));
+        $vendor_phone = formatPhoneNumber($row['vendor_phone']);
         $vendor_extension = nullable_htmlentities($row['vendor_extension']);
         $vendor_email = nullable_htmlentities($row['vendor_email']);
         $vendor_website = nullable_htmlentities($row['vendor_website']);
@@ -187,49 +186,73 @@ if (isset($_GET['ticket_id'])) {
 
         if($project_manager) {
             $sql_project_manager = mysqli_query($mysqli,"SELECT * FROM users WHERE user_id = $project_manager");
-            $row = mysqli_fetch_assoc($sql_project_manager);
+            $row = mysqli_fetch_array($sql_project_manager);
             $project_manager_name = nullable_htmlentities($row['user_name']);
         }
 
         if ($contact_id) {
             //Get Contact Ticket Stats
             $ticket_related_open = mysqli_query($mysqli, "SELECT COUNT(ticket_id) AS ticket_related_open FROM tickets WHERE ticket_status != 'Closed' AND ticket_contact_id = $contact_id ");
-            $row = mysqli_fetch_assoc($ticket_related_open);
+            $row = mysqli_fetch_array($ticket_related_open);
             $ticket_related_open = intval($row['ticket_related_open']);
 
             $ticket_related_closed = mysqli_query($mysqli, "SELECT COUNT(ticket_id) AS ticket_related_closed  FROM tickets WHERE ticket_status = 'Closed' AND ticket_contact_id = $contact_id ");
-            $row = mysqli_fetch_assoc($ticket_related_closed);
+            $row = mysqli_fetch_array($ticket_related_closed);
             $ticket_related_closed = intval($row['ticket_related_closed']);
 
             $ticket_related_total = mysqli_query($mysqli, "SELECT COUNT(ticket_id) AS ticket_related_total FROM tickets WHERE ticket_contact_id = $contact_id ");
-            $row = mysqli_fetch_assoc($ticket_related_total);
+            $row = mysqli_fetch_array($ticket_related_total);
             $ticket_related_total = intval($row['ticket_related_total']);
         }
 
         //Get Total Ticket Time
         $ticket_total_reply_time = mysqli_query($mysqli, "SELECT SEC_TO_TIME(SUM(TIME_TO_SEC(ticket_reply_time_worked))) AS ticket_total_reply_time FROM ticket_replies WHERE ticket_reply_archived_at IS NULL AND ticket_reply_ticket_id = $ticket_id");
-        $row = mysqli_fetch_assoc($ticket_total_reply_time);
+        $row = mysqli_fetch_array($ticket_total_reply_time);
         $ticket_total_reply_time = nullable_htmlentities($row['ticket_total_reply_time']);
+
+
+        // Client Tags
+        $client_tag_name_display_array = array();
+        $client_tag_id_array = array();
+        $sql_client_tags = mysqli_query($mysqli, "SELECT * FROM client_tags LEFT JOIN tags ON client_tags.tag_id = tags.tag_id WHERE client_id = $client_id ORDER BY tag_name ASC");
+        while ($row = mysqli_fetch_array($sql_client_tags)) {
+
+            $client_tag_id = intval($row['tag_id']);
+            $client_tag_name = nullable_htmlentities($row['tag_name']);
+            $client_tag_color = nullable_htmlentities($row['tag_color']);
+            if (empty($client_tag_color)) {
+                $client_tag_color = "dark";
+            }
+            $client_tag_icon = nullable_htmlentities($row['tag_icon']);
+            if (empty($client_tag_icon)) {
+                $client_tag_icon = "tag";
+            }
+
+            $client_tag_id_array[] = $client_tag_id;
+            $client_tag_name_display_array[] = "<span class='badge text-light p-1 mr-1' style='background-color: $client_tag_color;'><i class='fa fa-fw fa-$client_tag_icon mr-2'></i>$client_tag_name</span>";
+        }
+        $client_tags_display = implode(' ', $client_tag_name_display_array);
+
 
         // Get the number of ticket Responses
         $ticket_responses_sql = mysqli_query($mysqli, "SELECT COUNT(ticket_reply_id) AS ticket_responses FROM ticket_replies WHERE ticket_reply_archived_at IS NULL AND ticket_reply_ticket_id = $ticket_id");
-        $row = mysqli_fetch_assoc($ticket_responses_sql);
+        $row = mysqli_fetch_array($ticket_responses_sql);
         $ticket_responses = intval($row['ticket_responses']);
 
         $ticket_all_comments_sql = mysqli_query($mysqli, "SELECT COUNT(ticket_reply_id) AS ticket_all_comments_count FROM ticket_replies WHERE ticket_reply_archived_at IS NULL AND ticket_reply_ticket_id = $ticket_id");
-        $row = mysqli_fetch_assoc($ticket_all_comments_sql);
+        $row = mysqli_fetch_array($ticket_all_comments_sql);
         $ticket_all_comments_count = intval($row['ticket_all_comments_count']);
 
         $ticket_internal_notes_sql = mysqli_query($mysqli, "SELECT COUNT(ticket_reply_id) AS ticket_internal_notes_count FROM ticket_replies WHERE ticket_reply_archived_at IS NULL AND ticket_reply_type = 'Internal' AND ticket_reply_ticket_id = $ticket_id");
-        $row = mysqli_fetch_assoc($ticket_internal_notes_sql);
+        $row = mysqli_fetch_array($ticket_internal_notes_sql);
         $ticket_internal_notes_count = intval($row['ticket_internal_notes_count']);
 
         $ticket_public_comments_sql = mysqli_query($mysqli, "SELECT COUNT(ticket_reply_id) AS ticket_public_comments_count FROM ticket_replies WHERE ticket_reply_archived_at IS NULL AND (ticket_reply_type = 'Public' OR ticket_reply_type = 'Client') AND ticket_reply_ticket_id = $ticket_id");
-        $row = mysqli_fetch_assoc($ticket_public_comments_sql);
+        $row = mysqli_fetch_array($ticket_public_comments_sql);
         $ticket_public_comments_count = intval($row['ticket_public_comments_count']);
 
         $ticket_events_sql = mysqli_query($mysqli, "SELECT COUNT(log_id) AS ticket_events_count FROM logs WHERE log_type = 'Ticket' AND  log_entity_id = $ticket_id");
-        $row = mysqli_fetch_assoc($ticket_events_sql);
+        $row = mysqli_fetch_array($ticket_events_sql);
         $ticket_events_count = intval($row['ticket_events_count']);
 
 
@@ -353,7 +376,7 @@ if (isset($_GET['ticket_id'])) {
                                     <?= $ticket_status_name ?>
                                 </span>
                             </div>
-                            <span class="text-secondary"><?= $ticket_subject ?></span>
+                            <small class="text-secondary"><?= $ticket_subject ?></small>
                         </div>
                     </div>
                 </div>
@@ -397,7 +420,7 @@ if (isset($_GET['ticket_id'])) {
                                             <i class="fas fa-fw fa-lightbulb mr-2"></i>Summarize
                                         </a>
                                         <a class="dropdown-item ajax-modal" href="#" data-modal-url="modals/ticket/ticket_merge.php?ticket_id=<?= $ticket_id ?>">
-                                            <i class="fas fa-fw fa-clone mr-2"></i>Merge Ticket
+                                            <i class="fas fa-fw fa-clone mr-2"></i>Merge
                                         </a>
                                         <?php if (empty($ticket_closed_at) && $client_id) { ?>
                                             <div class="dropdown-divider"></div>
@@ -440,38 +463,35 @@ if (isset($_GET['ticket_id'])) {
             <div class="card card-body">
 
                 <div title="<?php echo $ticket_updated_at; ?>">
-                    <i class="fa fa-fw fa-history text-secondary mr-2"></i>Updated: <strong><?= date('M d, Y • g:i A', strtotime($ticket_updated_at)) . "</strong> <span class='text-muted small'>($ticket_updated_at_ago)</span>" ?>
+                    <i class="fa fa-fw fa-history text-secondary mr-2"></i>Updated: <strong><?php echo $ticket_updated_at_ago; ?></strong>
                 </div>
 
                 <!-- Ticket assign (disable if closed -->
                 <?php if (empty($ticket_closed_at)) { ?>
                     <div class="mt-1">
-                        <i class="fas fa-fw fa-user-tie mr-2 text-secondary"></i>Agent:
                         <a class="ajax-modal" href="#"
-                            data-modal-url="modals/ticket/ticket_assign.php?id=<?= $ticket_id ?>">
-                            <?= $ticket_assigned_to_display ?>
+                           data-modal-url="modals/ticket/ticket_assign.php?id=<?= $ticket_id ?>">
+                            <i class="fas fa-fw fa-user mr-2 text-secondary"></i><?php echo $ticket_assigned_to_display; ?>
                         </a>
                     </div>
                 <?php } else { ?>
                     <div class="mt-1">
-                        <i class="fas fa-fw fa-user-check mr-2 text-secondary"></i>Agent: <?php echo $ticket_assigned_to_display; ?>
+                        <i class="fas fa-fw fa-user mr-2 text-secondary"></i><?php echo $ticket_assigned_to_display; ?>
                     </div>
                 <?php } ?>
                 <!-- End ticket assign -->
-                <div class="mt-1">
-                    <span class="text-info" id="ticket_collision_viewing"></span>
-                </div>
             </div>
 
             <div class="card card-body">
                 <div>
-                    <a href="#" title="Priority"
+                    <i class="fa fa-fw fa-thermometer-half text-secondary mr-1"></i>
+                    <a href="#"
                         <?php if (lookupUserPermission("module_support") >= 2 && empty($ticket_closed_at)) { ?>
                             class="ajax-modal"
                             data-modal-url="modals/ticket/ticket_priority.php?id=<?= $ticket_id ?>"
                         <?php } ?>
                     >
-                        <?= $ticket_priority_display ?>
+                        <?php echo $ticket_priority_display; ?>
                     </a>
                 </div>
 
@@ -498,14 +518,14 @@ if (isset($_GET['ticket_id'])) {
                         </div>
                     <?php } else { ?>
                         <div class="mt-1">
-                            <i class="fa fa-fw fa-dollar-sign text-secondary mr-2"></i>Billable:
+                            <i class="fa fa-fw fa-dollar-sign text-secondary mr-2"></i>Ticket is
                             <a class="ajax-modal" href="#"
                                data-modal-url="modals/ticket/ticket_billable.php?id=<?= $ticket_id ?>">
                                 <?php
                                 if ($ticket_billable == 1) {
-                                    echo "<span class='text-bold text-dark'>Yes</span>";
+                                    echo "<span class='text-bold text-dark'>Billable</span>";
                                 } else {
-                                    echo "<span class='text-muted'>No</span>";
+                                    echo "<span class='text-muted'>Not Billable</span>";
                                 }
                                 ?>
                             </a>
@@ -519,11 +539,16 @@ if (isset($_GET['ticket_id'])) {
 
             <div class="card card-body">
                 <?php if ($task_count) { ?>
-                    <div><strong>Tasks</strong> <?= "$completed_task_count/$task_count ($tasks_completed_percent%)" ?></div>
-                    <div class="progress" style="height: 20px;">
-                        <div class="progress-bar" style="width: <?php echo $tasks_completed_percent; ?>%;"></div>
+                    Tasks Completed
+                    <span class="float-right text-bold"><?php echo $tasks_completed_percent; ?>%</span>
+                    <div class="progress mt-2" style="height: 20px;">
+                        <div class="progress-bar" style="width: <?php echo $tasks_completed_percent; ?>%;"><?php echo $completed_task_count; ?> / <?php echo $task_count; ?></div>
                     </div>
                 <?php } ?>
+
+                <div class="mt-2">
+                    <span class="text-info" id="ticket_collision_viewing"></span>
+                </div>
             </div>
 
         </div>
@@ -534,9 +559,9 @@ if (isset($_GET['ticket_id'])) {
 
                 <div class="card card-dark mb-3">
 
-                    <div class="card-header px-3 py-2">
-                        <h5 class="card-title mt-1">
-                            Description / Comments
+                    <div class="card-header bg-dark">
+                        <h5 class="card-title">
+                            Ticket Details
                         </h5>
                         <?php if (empty($ticket_closed_at)) { ?>
                         <div class="card-tools">
@@ -545,14 +570,14 @@ if (isset($_GET['ticket_id'])) {
                         <?php } ?>
                     </div>
 
-                    <div class="card-body p-3 prettyContent" id="ticketDetails">
+                    <div class="card-body prettyContent" id="ticketDetails">
                         <?php echo $ticket_details; ?>
 
                         <?php
-                        while ($ticket_attachment = mysqli_fetch_assoc($sql_ticket_attachments)) {
+                        while ($ticket_attachment = mysqli_fetch_array($sql_ticket_attachments)) {
                             $name = nullable_htmlentities($ticket_attachment['ticket_attachment_name']);
                             $ref_name = nullable_htmlentities($ticket_attachment['ticket_attachment_reference_name']);
-                            echo "<hr class=''><i class='fas fa-fw fa-paperclip text-secondary mr-1'></i>$name <a target='_blank' class='mr-1 ml-1' href='../uploads/tickets/$ticket_id/$ref_name'>[View]</a><a href='../uploads/tickets/$ticket_id/$ref_name' download='$name'>[Download]</a>";
+                            echo "<hr class=''><i class='fas fa-fw fa-paperclip text-secondary mr-1'></i>$name | <a href='../uploads/tickets/$ticket_id/$ref_name' download='$name'><i class='fas fa-fw fa-download mr-1'></i>Download</a> | <a target='_blank' href='../uploads/tickets/$ticket_id/$ref_name'><i class='fas fa-fw fa-external-link-alt mr-1'></i>View</a>";
                         }
                         ?>
                     </div>
@@ -562,24 +587,26 @@ if (isset($_GET['ticket_id'])) {
                 <!-- Only show ticket reply modal if status is not closed -->
                 <?php if (lookupUserPermission("module_support") >= 2 && empty($ticket_resolved_at) && empty($ticket_closed_at)) { ?>
 
+
+
                         <form action="post.php" method="post" autocomplete="off">
                             <input type="hidden" name="ticket_id" id="ticket_id" value="<?php echo $ticket_id; ?>">
                             <input type="hidden" name="client_id" id="client_id" value="<?php echo $client_id; ?>">
 
-                            <div class="card card-body d-print-none p-3">
+                            <div class="card card-body d-print-none pb-0">
 
-                                <div class="form-group mb-0">
+                                <div class="form-group">
                                     <div class="btn-group btn-block btn-group-toggle" data-toggle="buttons">
                                         <label class="btn btn-outline-dark active">
-                                            <input type="radio" name="public_reply_type" value="0" checked>Internal
+                                            <input type="radio" name="public_reply_type" value="0" checked>Internal Note
                                         </label>
                                         <?php if ($contact_email) { ?>
                                         <label class="btn btn-outline-info">
-                                            <input type="radio" name="public_reply_type" value="2">Public + Email
+                                            <input type="radio" name="public_reply_type" value="2">Public Comment & Email
                                         </label>
                                         <?php } ?>
                                         <label class="btn btn-outline-info">
-                                            <input type="radio" name="public_reply_type" value="1">Public
+                                            <input type="radio" name="public_reply_type" value="1">Public Comment
                                         </label>
                                     </div>
                                 </div>
@@ -593,10 +620,11 @@ if (isset($_GET['ticket_id'])) {
                                 </textarea>
                             </div>
 
-                            <div class="form-row">
-                                <div class="col-md-3">
-                                    <div class="form-group">
-                                        <div class="input-group">
+                            <div class="card card-body pb-0">
+
+                                <div class="form-row">
+                                    <div class="col-md-3">
+                                        <div class="input-group mb-3">
                                             <select class="form-control select2" name="status" required>
 
                                                 <!-- Show all active ticket statuses, apart from new or closed as these are system-managed -->
@@ -606,7 +634,7 @@ if (isset($_GET['ticket_id'])) {
                                                     $status_snippet = "AND ticket_status_id != 4";
                                                 }
                                                 $sql_ticket_status = mysqli_query($mysqli, "SELECT * FROM ticket_statuses WHERE ticket_status_id != 1 AND ticket_status_id != 5 AND ticket_status_active = 1 $status_snippet ORDER BY ticket_status_order");
-                                                while ($row = mysqli_fetch_assoc($sql_ticket_status)) {
+                                                while ($row = mysqli_fetch_array($sql_ticket_status)) {
                                                     $ticket_status_id_select = intval($row['ticket_status_id']);
                                                     $ticket_status_name_select = nullable_htmlentities($row['ticket_status_name']); ?>
 
@@ -616,12 +644,10 @@ if (isset($_GET['ticket_id'])) {
                                             </select>
                                         </div>
                                     </div>
-                                </div>
 
-                                <!-- Time Tracking -->
-                                <div class="col-md-6">
-                                    <div class="form-group">
-                                        <div class="input-group">
+                                    <!-- Time Tracking -->
+                                    <div class="col-md-6">
+                                        <div class="input-group mb-3">
                                             <div class="input-group-prepend px-0 col-2">
                                                 <input type="text" class="form-control" inputmode="numeric" id="hours" name="hours" placeholder="Hrs" min="0" max="23" pattern="0?[0-9]|1[0-9]|2[0-3]">
                                             </div>
@@ -640,14 +666,14 @@ if (isset($_GET['ticket_id'])) {
                                             </div>
                                         </div>
                                     </div>
-                                </div>
 
-                                <div class="col-md-3">
-                                    <div class="btn-toolbar float-right mb-3">
-                                        <button type="submit" id="ticket_add_reply" name="add_ticket_reply" class="btn btn-success ml-3"><i class="fas fa-check mr-2"></i>Submit</button>
+                                    <div class="col-md-3">
+                                        <div class="btn-toolbar float-right">
+                                            <button type="submit" id="ticket_add_reply" name="add_ticket_reply" class="btn btn-success ml-3"><i class="fas fa-check mr-2"></i>Submit</button>
+                                        </div>
                                     </div>
-                                </div>
 
+                                </div>
                             </div>
 
                         </form>
@@ -658,7 +684,7 @@ if (isset($_GET['ticket_id'])) {
                 <!-- Ticket replies -->
                 <?php
 
-                while ($row = mysqli_fetch_assoc($sql_ticket_replies)) {
+                while ($row = mysqli_fetch_array($sql_ticket_replies)) {
                     $ticket_reply_id = intval($row['ticket_reply_id']);
                     $ticket_reply = $purifier->purify($row['ticket_reply']);
                     $ticket_reply_type = nullable_htmlentities($row['ticket_reply_type']);
@@ -679,7 +705,7 @@ if (isset($_GET['ticket_id'])) {
                         $user_avatar = nullable_htmlentities($row['user_avatar']);
                         $user_initials = initials($row['user_name']);
                         $avatar_link = "../uploads/users/$user_id/$user_avatar";
-                        $ticket_reply_time_worked = $row['ticket_reply_time_worked'];
+                        $ticket_reply_time_worked = date_create($row['ticket_reply_time_worked']);
                     }
 
                     $sql_ticket_reply_attachments = mysqli_query(
@@ -706,19 +732,12 @@ if (isset($_GET['ticket_id'])) {
                                         </span>
                                     <?php } ?>
 
-                                    <div class="ml-2">
+                                    <div class="ml-3">
                                         <h3 class="card-title"><?php echo $ticket_reply_by_display; ?></h3>
                                         <div>
-                                            <?php if ($ticket_reply_type !== "Client" && $ticket_reply_time_worked !== "00:00:00") { ?>
+                                            <?php if ($ticket_reply_type !== "Client") { ?>
                                                 <div>
-                                                    <br>
-                                                    <small>
-                                                        <i class="far fa-fw fa-clock text-secondary"></i>
-                                                        Time worked:
-                                                        <span class="text-muted">
-                                                            <?= formatDuration($ticket_reply_time_worked) ?>
-                                                        </span>
-                                                    </small>
+                                                    <br><small class="text-muted">Time worked: <?php echo date_format($ticket_reply_time_worked, 'H:i:s'); ?></small>
                                                 </div>
                                             <?php } ?>
                                         </div>
@@ -770,7 +789,7 @@ if (isset($_GET['ticket_id'])) {
                             <?php echo $ticket_reply; ?>
 
                             <?php
-                            while ($ticket_attachment = mysqli_fetch_assoc($sql_ticket_reply_attachments)) {
+                            while ($ticket_attachment = mysqli_fetch_array($sql_ticket_reply_attachments)) {
                                 $name = nullable_htmlentities($ticket_attachment['ticket_attachment_name']);
                                 $ref_name = nullable_htmlentities($ticket_attachment['ticket_attachment_reference_name']);
                                 echo "<hr><i class='fas fa-fw fa-paperclip text-secondary mr-1'></i>$name | <a href='../uploads/tickets/$ticket_id/$ref_name' download='$name'><i class='fas fa-fw fa-download mr-1'></i>Download</a> | <a target='_blank' href='../uploads/tickets/$ticket_id/$ref_name'><i class='fas fa-fw fa-external-link-alt mr-1'></i>View</a>";
@@ -790,10 +809,10 @@ if (isset($_GET['ticket_id'])) {
 
             <div class="col-md-3">
 
-                <!-- Ticket activity right card -->
-                <div class="card">
-                    <div class="card-header px-3 py-2">
-                        <h5 class="card-title mt-1"><i class="fas fa-fw fa-history mr-2"></i>Activity Summary</h5>
+                <!-- Ticket details right card -->
+                <div class="card <?php if(!$ticket_resolved_at) { echo "collapsed-card"; } ?>">
+                    <div class="card-header">
+                        <h5 class="card-title"><i class="fas fa-fw fa-life-ring mr-2"></i>Ticket Details</h5>
 
                         <div class="card-tools">
                             <button type="button" class="btn btn-tool" data-card-widget="collapse">
@@ -801,50 +820,49 @@ if (isset($_GET['ticket_id'])) {
                             </button>
                         </div>
                     </div>
-                    <div class="card-body p-3 ">
+                    <div class="card-body">
 
                         <!-- Created -->
-                        <div>
-                            <i class="fas fa-fw fa-calendar-alt text-secondary mr-1"></i><strong class="mr-1">Created:</strong><?= date('M d, Y', strtotime($ticket_date)) ?>
-                            <span class="text-muted small">(<?= $ticket_created_at_ago ?>)</span>
+                        <div title="<?php echo $ticket_created_at; ?>">
+                            <i class="fa fa-fw fa-calendar text-secondary mr-2"></i><strong>Created: </strong><?php echo "$ticket_date ($ticket_created_at_ago)"; ?>
                         </div>
 
                         <!-- Created by -->
-                        <?php if ($ticket_created_by) {
-                            $row = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT user_name FROM users WHERE user_id = $ticket_created_by"));
+                        <?php if (!empty($ticket_created_by)) {
+                            $row = mysqli_fetch_array(mysqli_query($mysqli, "SELECT user_name FROM users WHERE user_id = $ticket_created_by"));
                             $ticket_created_by_display = nullable_htmlentities($row['user_name']);
                             ?>
 
-                            <div class="mt-2">
-                                <i class="far fa-fw fa-user text-secondary mr-1"></i><strong class="mr-1">Created by:</strong><?= $ticket_created_by_display ?>
+                            <div class="mt-1">
+                                <i class="far fa-fw fa-user text-secondary mr-2"></i><strong>Created by: </strong><?php echo $ticket_created_by_display; ?>
                             </div>
                         <?php } ?>
 
                         <!-- Source -->
-                        <?php if ($ticket_source) { ?>
-                            <div class="mt-2">
-                                <i class="fas fa-fw fa-inbox text-secondary mr-1"></i><strong class="mr-1">Source:</strong><?= $ticket_source ?>
+                        <?php if (!empty($ticket_source)) { ?>
+                            <div class="mt-1">
+                                <i class="far fa-fw fa-question-circle text-secondary mr-2"></i><strong>Source: </strong><?php echo $ticket_source; ?>
                             </div>
                         <?php } ?>
 
                         <!-- Category -->
-                        <?php if ($ticket_category) { ?>
-                            <div class="mt-2">
-                                <i class="fas fa-fw fa-layer-group text-secondary mr-1"></i><strong class="mr-1">Category:</strong><?= $ticket_category_display ?>
+                        <?php if ($ticket_category > 0) { ?>
+                            <div class="mt-1">
+                                <i class="fas fa-fw fa-layer-group mr-2 text-secondary"></i><strong>Category: </strong><?php echo $ticket_category_display; ?>
                             </div>
                         <?php } ?>
 
                         <!-- First response (for SLA) -->
                         <?php if ($ticket_first_response_at) { ?>
-                            <div class="mt-2">
-                                <i class="fas fa-fw fa-reply-all text-secondary mr-1"></i><strong class="mr-1">1st  resp:</strong><?= date('M d • g:i A', strtotime($ticket_first_response_at)) ?>
+                            <div title="First Response: <?php echo $ticket_created_at; ?>">
+                                <i class="fa fa-fw fa-user-clock text-secondary mr-2"></i><strong>FR: </strong><?php echo "$ticket_first_response_at"; ?>
                             </div>
                         <?php } ?>
 
                         <!-- Time tracking -->
                         <?php if ($ticket_total_reply_time) { ?>
-                            <div class="mt-2">
-                                <i class="fas fa-fw fa-stopwatch text-secondary mr-1"></i><strong class="mr-1">Total time:</strong><?= formatDuration($ticket_total_reply_time) ?>
+                            <div class="mt-1">
+                                <i class="far fa-fw fa-clock text-secondary mr-2"></i><strong>Time worked: </strong><?php echo $ticket_total_reply_time; ?>
                             </div>
                         <?php } ?>
 
@@ -857,34 +875,34 @@ if (isset($_GET['ticket_id'])) {
 <!--                        --><?php //} ?>
 
                         <!-- Resolved -->
-                        <?php if ($ticket_resolved_at) { ?>
+                        <?php if (!empty($ticket_resolved_at)) { ?>
                             <hr>
-                            <div class="mt-2" title="<?= $ticket_resolved_at ?>">
-                                <i class="fas fa-fw fa-check text-secondary mr-1"></i><strong class="mr-1">Resolved:</strong><?= date('M d, Y • g:i A', strtotime($ticket_resolved_at)) . " ($ticket_resolved_at_ago)" ?>
+                            <div class="mt-1" title="<?php echo $ticket_resolved_at; ?>">
+                                <i class="fa fa-fw fa-check text-secondary mr-2"></i><strong>Resolved: </strong><?php echo "$ticket_resolved_date ($ticket_resolved_at_ago)"; ?>
                             </div>
                         <?php } ?>
 
                         <!-- Ticket closure info -->
-                        <?php if ($ticket_closed_at) {
+                        <?php if (!empty($ticket_closed_at)) {
 
                             $ticket_closed_by_display = 'User';
                             if (!empty($ticket_closed_by)) {
                                 $sql_closed_by = mysqli_query($mysqli, "SELECT user_name FROM users WHERE user_id = $ticket_closed_by");
-                                $row = mysqli_fetch_assoc($sql_closed_by);
+                                $row = mysqli_fetch_array($sql_closed_by);
                                 $ticket_closed_by_display = nullable_htmlentities($row['user_name']);
                             }
                             ?>
-                            <div class="mt-2">
-                                <i class="fas fa-fw fa-user text-secondary mr-1"></i><strong class="mr-1">Closed by:</strong><?= ucwords($ticket_closed_by_display) ?>
+                            <div class="mt-1">
+                                <i class="fa fa-fw fa-user text-secondary mr-2"></i><strong>Closed by: </strong><?php echo ucwords($ticket_closed_by_display); ?>
                             </div>
 
-                            <div class="mt-2">
-                                <i class="fas fa-fw fa-clock text-secondary mr-1"></i><strong class="mr-1">Closed:</strong><?= date('M d, Y • g:i A', strtotime($ticket_closed_at)) . " ($ticket_closed_at_ago)" ?>
+                            <div class="mt-1" title="<?php echo $ticket_closed_at; ?>">
+                                <i class="fa fa-fw fa-clock text-secondary mr-2"></i><strong>Closed: </strong><?php echo "$ticket_closed_date ($ticket_closed_at_ago)"; ?>
                             </div>
 
                             <?php if ($ticket_feedback) { ?>
-                                <div class="mt-2">
-                                    <i class="fa fa-fw fa-comment-dots text-secondary mr-1"></i><strong>Feedback: </strong><?php echo $ticket_feedback; ?>
+                                <div class="mt-1">
+                                    <i class="fa fa-fw fa-comment-dots text-secondary mr-2"></i><strong>Feedback: </strong><?php echo $ticket_feedback; ?>
                                 </div>
                             <?php } ?>
 
@@ -898,8 +916,8 @@ if (isset($_GET['ticket_id'])) {
                 <!-- Tasks Card -->
                 <?php if (empty($ticket_resolved_at) || (!empty($ticket_resolved_at) && $task_count > 0)) { ?>
                     <div class="card">
-                        <div class="card-header px-3 py-2">
-                            <h5 class="card-title mt-1"><i class="fas fa-fw fa-tasks mr-2"></i>Tasks</h5>
+                        <div class="card-header">
+                            <h5 class="card-title"><i class="fas fa-fw fa-tasks mr-2"></i>Tasks</h5>
                             <?php if (empty($ticket_resolved_at) && lookupUserPermission("module_support") >= 2) { ?>
                             <div class="card-tools">
                                 <div class="dropdown dropleft text-center">
@@ -943,82 +961,25 @@ if (isset($_GET['ticket_id'])) {
 
                             <table class="table table-sm" id="tasks">
                                 <?php
-                                while ($row = mysqli_fetch_assoc($sql_tasks)) {
+                                while($row = mysqli_fetch_array($sql_tasks)){
                                     $task_id = intval($row['task_id']);
                                     $task_name = nullable_htmlentities($row['task_name']);
                                     //$task_description = nullable_htmlentities($row['task_description']); // not in db yet
                                     $task_completion_estimate = intval($row['task_completion_estimate']);
                                     $task_completed_at = nullable_htmlentities($row['task_completed_at']);
-
-                                    // Check for approvals
-                                    $task_needs_approval = false;
-                                    $task_needs_approval = mysqli_num_rows(mysqli_query(
-                                            $mysqli,
-                                            "SELECT 1 FROM task_approvals
-                                                 WHERE approval_task_id = $task_id
-                                                   AND approval_status IN ('pending','declined')
-                                                 LIMIT 1"
-                                        )) > 0;
-
-                                    $approval_id = 0;
-                                    $user_can_approve = false;
-                                    $approval_rows = mysqli_query($mysqli, "
-                                        SELECT approval_id, approval_scope, approval_type, approval_required_user_id, approval_created_by
-                                        FROM task_approvals WHERE approval_task_id = $task_id AND approval_status = 'pending'
-                                    ");
-
-                                    while ($approval = mysqli_fetch_assoc($approval_rows)) {
-
-                                        $scope = nullable_htmlentities($approval['approval_scope']);
-                                        $type = nullable_htmlentities($approval['approval_type']);
-                                        $required_user = intval($approval['approval_required_user_id']);
-                                        $created_by = intval($approval['approval_created_by']);
-
-                                        // Named, specific user?
-                                        if ($scope == 'internal' && $type == 'specific' && $required_user == $session_user_id) {
-                                            $user_can_approve = true;
-                                            $approval_id = intval($approval['approval_id']);
-                                            continue;
-                                        }
-
-                                        // Any internal user, but the one who created the task
-                                        if ($scope == 'internal' && $type == 'any' && $created_by !== $session_user_id) {
-                                            $user_can_approve = true;
-                                            $approval_id = intval($approval['approval_id']);
-                                            continue;
-                                        }
-
-                                    }
-
                                     ?>
                                     <tr data-task-id="<?= $task_id ?>">
-                                        <td class="px-3">
+                                        <td>
                                             <?php if ($task_completed_at) { ?>
                                                 <i class="far fa-check-square text-success"></i>
                                             <?php } elseif (lookupUserPermission("module_support") >= 2) { ?>
-
-                                                <?php if ($task_needs_approval) { ?>
-                                                    <i class="fas fa-shield-alt text-warning"
-                                                       data-toggle="tooltip"
-                                                       data-placement="top"
-                                                       title="Approval required"></i>
-
-                                                    <?php if ($user_can_approve) { ?>
-                                                        <a class="confirm-link" href="post.php?approve_ticket_task=<?= $task_id ?>&approval_id=<?= $approval_id ?>&csrf_token=<?= $_SESSION['csrf_token'] ?>">
-                                                            <i class="fas fa-thumbs-up text-green"></i>
-                                                        </a>
-                                                    <?php } ?>
-
-                                                <?php } else { ?>
-                                                    <a href="post.php?complete_task=<?php echo $task_id; ?>">
-                                                        <i class="far fa-square text-dark"></i>
-                                                    </a>
-                                                <?php } ?>
-
+                                                <a href="post.php?complete_task=<?php echo $task_id; ?>">
+                                                    <i class="far fa-square text-dark"></i>
+                                                </a>
                                             <?php } ?>
-                                            <span class="text-dark ml-2"><?= $task_name ?></span>
+                                            <span class="text-dark ml-2"><?php echo $task_name; ?></span>
                                         </td>
-                                        <td class="px-2">
+                                        <td>
                                             <div class="float-right">
 
                                                 <div class="btn-group">
@@ -1036,12 +997,6 @@ if (isset($_GET['ticket_id'])) {
                                                                    data-modal-url="modals/ticket/ticket_task_edit.php?id=<?= $task_id ?>">
                                                                     <i class="fas fa-fw fa-edit mr-2"></i>Edit
                                                                 </a>
-                                                                <?php if (!$task_completed_at) { ?>
-                                                                    <a class="dropdown-item ajax-modal" href="#"
-                                                                       data-modal-url="modals/ticket/ticket_task_approver_add.php?id=<?= $task_id ?>">
-                                                                        <i class="fas fa-fw fa-shield-alt mr-2"></i>Add Approvers
-                                                                    </a>
-                                                                <?php } ?>
                                                                 <?php if ($task_completed_at) { ?>
                                                                     <a class="dropdown-item" href="post.php?undo_complete_task=<?php echo $task_id; ?>">
                                                                         <i class="fas fa-fw fa-arrow-circle-left mr-2"></i>Mark incomplete
@@ -1071,8 +1026,8 @@ if (isset($_GET['ticket_id'])) {
                 <!-- Contact card -->
                 <?php if ($contact_id) { ?>
                     <div class="card">
-                        <div class="card-header px-3 py-2">
-                            <h5 class="card-title mt-1"><i class="fas fa-fw fa-user-check mr-2"></i>Contact</h5>
+                        <div class="card-header">
+                            <h5 class="card-title"><i class="fas fa-fw fa-user-check mr-2"></i>Contact</h5>
                             <?php if (empty($ticket_resolved_at) && lookupUserPermission("module_support") >= 2) { ?>
                             <div class="card-tools">
                                 <a class="btn btn-tool ajax-modal" href="#"
@@ -1082,7 +1037,7 @@ if (isset($_GET['ticket_id'])) {
                             </div>
                             <?php } ?>
                         </div>
-                        <div class="card-body p-3">
+                        <div class="card-body">
 
                             <div>
                                 <i class="fa fa-fw fa-user text-secondary mr-2"></i><a href="#" class="ajax-modal"
@@ -1126,29 +1081,29 @@ if (isset($_GET['ticket_id'])) {
                 <?php if (empty($ticket_closed_at) && mysqli_num_rows($sql_ticket_watchers) > 0) { ?>
 
                     <div class="card">
-                        <div class="card-header px-3 py-2">
-                            <h5 class="card-title mt-1"><i class="fas fa-fw fa-eye mr-2"></i>Watchers</h5>
+                        <div class="card-header">
+                            <h5 class="card-title"><i class="fas fa-fw fa-eye mr-2"></i>Watchers</h5>
                             <?php if (empty($ticket_resolved_at) && lookupUserPermission("module_support") >= 2) { ?>
                             <div class="card-tools">
                                 <a class="btn btn-tool ajax-modal" href="#" data-modal-url="modals/ticket/ticket_add_watcher.php?ticket_id=<?= $ticket_id ?>">
-                                    <i class="fas fa-fw fa-user-plus"></i>
+                                    <i class="fas fa-fw fa-plus"></i>
                                 </a>
                             </div>
                             <?php } ?>
                         </div>
-                        <div class="card-body p-3">
+                        <div class="card-body">
 
                             <?php
                             // Get Watchers
-                            while ($row = mysqli_fetch_assoc($sql_ticket_watchers)) {
+                            while ($row = mysqli_fetch_array($sql_ticket_watchers)) {
                                 $watcher_id = intval($row['watcher_id']);
                                 $ticket_watcher_email = nullable_htmlentities($row['watcher_email']);
                                 ?>
                                 <div class='mt-1'>
-                                    <i class="fa fa-fw fa-envelope text-secondary mr-2"></i><?php echo $ticket_watcher_email; ?>
+                                    <i class="fa fa-fw fa-eye text-secondary mr-2"></i><?php echo $ticket_watcher_email; ?>
                                     <?php if (empty($ticket_closed_at)) { ?>
                                         <a class="confirm-link float-right" href="post.php?delete_ticket_watcher=<?php echo $watcher_id; ?>">
-                                            <i class="fas fa-fw fa-times text-secondary"></i>
+                                            <i class="fas fa-fw fa-trash-alt text-secondary"></i>
                                         </a>
                                     <?php } ?>
                                 </div>
@@ -1162,8 +1117,8 @@ if (isset($_GET['ticket_id'])) {
                 <!-- Asset card -->
                 <?php if ($asset_id) { ?>
                     <div class="card mb-3">
-                        <div class="card-header px-3 py-2">
-                            <h5 class="card-title mt-1"><i class="fas fa-fw fa-desktop mr-2"></i>Assets</h5>
+                        <div class="card-header">
+                            <h5 class="card-title"><i class="fas fa-fw fa-desktop mr-2"></i>Assets</h5>
                             <?php if (empty($ticket_resolved_at) && lookupUserPermission("module_support") >= 2) { ?>
                             <div class="card-tools">
                                 <a class="btn btn-tool ajax-modal" href="#" data-modal-url="modals/ticket/ticket_edit_asset.php?id=<?= $ticket_id ?>">
@@ -1172,7 +1127,7 @@ if (isset($_GET['ticket_id'])) {
                             </div>
                             <?php } ?>
                         </div>
-                        <div class="card-body p-3">
+                        <div class="card-body">
                             <div>
                                 <a class="ajax-modal" href="#" data-modal-size="lg"
                                     data-modal-url="modals/asset/asset_details.php?<?= $client_url ?>&id=<?= $asset_id ?>">
@@ -1180,7 +1135,7 @@ if (isset($_GET['ticket_id'])) {
                                 </a>
                             </div>
                             <?php
-                            while ($row = mysqli_fetch_assoc($sql_additional_assets)) {
+                            while ($row = mysqli_fetch_array($sql_additional_assets)) {
                                 $additional_asset_id = intval($row['asset_id']);
                                 $additional_asset_name = nullable_htmlentities($row['asset_name']);
                                 $additional_asset_type = nullable_htmlentities($row['asset_type']);
@@ -1193,7 +1148,7 @@ if (isset($_GET['ticket_id'])) {
                                     </a>
                                     <?php if (empty($ticket_closed_at)) { ?>
                                         <a class="confirm-link float-right" href="post.php?delete_ticket_additional_asset=<?php echo $additional_asset_id; ?>&ticket_id=<?php echo $ticket_id; ?>" title="Remove asset from ticket">
-                                            <i class="fas fa-fw fa-times text-secondary"></i>
+                                            <i class="fas fa-fw fa-trash-alt text-secondary"></i>
                                         </a>
                                     <?php } ?>
                                 </div>
@@ -1206,11 +1161,12 @@ if (isset($_GET['ticket_id'])) {
                 <?php } // End if asset_id ?>
                 <!-- End Asset card -->
 
+
                 <!-- Vendor card -->
                 <?php if ($vendor_id) { ?>
                     <div class="card mb-3">
-                        <div class="card-header px-3 py-2">
-                            <h5 class="card-title mt-1"><i class="fas fa-fw fa-building mr-2"></i>Vendor</h5>
+                        <div class="card-header">
+                            <h5 class="card-title"><i class="fas fa-fw fa-building mr-2"></i>Vendor</h5>
                             <?php if (empty($ticket_resolved_at) && lookupUserPermission("module_support") >= 2) { ?>
                             <div class="card-tools">
                                 <a class="btn btn-tool ajax-modal" href="#" data-modal-url="modals/ticket/ticket_edit_vendor.php?ticket_id=<?= $ticket_id ?>">
@@ -1219,7 +1175,7 @@ if (isset($_GET['ticket_id'])) {
                             </div>
                             <?php } ?>
                         </div>
-                        <div class="card-body p-3">
+                        <div class="card-body">
 
                             <div>
                                 <i class="fa fa-fw fa-building text-secondary mr-2"></i><strong><?php echo $vendor_name; ?></strong>
@@ -1264,8 +1220,8 @@ if (isset($_GET['ticket_id'])) {
                 <!-- project card -->
                 <?php if ($project_id) { ?>
                     <div class="card">
-                        <div class="card-header px-3 py-2">
-                            <h5 class="card-title mt-1"><i class="fas fa-fw fa-project-diagram mr-2"></i>Project</h5>
+                        <div class="card-header">
+                            <h5 class="card-title"><i class="fas fa-fw fa-project-diagram mr-2"></i>Project</h5>
                             <?php if (empty($ticket_resolved_at) && lookupUserPermission("module_support") >= 2) { ?>
                             <div class="card-tools">
                                 <button type="button" class="btn btn-tool ajax-modal" data-modal-url="modals/ticket/ticket_edit_project.php?id=<?= $ticket_id ?>">
@@ -1274,15 +1230,15 @@ if (isset($_GET['ticket_id'])) {
                             </div>
                             <?php } ?>
                         </div>
-                        <div class="card-body p-3">
+                        <div class="card-body">
                             <div>
-                                <i class="fa fa-fw fa-project-diagram text-secondary mr-2"></i><a href="project_details.php?project_id=<?php echo $project_id; ?>" target="_blank"><strong><?= $project_name ?><i class="fa fa-fw fa-external-link-alt ml-1"></i></strong>
+                                <i class="fa fa-fw fa-project-diagram text-secondary mr-2"></i><a href="project_details.php?project_id=<?php echo $project_id; ?>" target="_blank"><strong><?php echo $project_name; ?><i class="fa fa-fw fa-external-link-alt text-secondary ml-2"></i></strong>
                                 </a>
                             </div>
 
                             <?php if ($project_manager) { ?>
                                 <div class="mt-2">
-                                    <i class="fa fa-fw fa-user-tie text-secondary mr-2"></i><?= $project_manager_name ?>
+                                    <i class="fa fa-fw fa-user-tie text-secondary mr-3"></i><?php echo $project_manager_name; ?>
                                 </div>
                             <?php } ?>
                         </div>

--- a/cron/mail_queue.php
+++ b/cron/mail_queue.php
@@ -43,7 +43,7 @@ class StaticTokenProvider implements OAuthTokenProvider {
  *  Load settings
  * ======================================================================= */
 $sql_settings = mysqli_query($mysqli, "SELECT * FROM settings WHERE company_id = 1");
-$row = mysqli_fetch_array($sql_settings);
+$row = mysqli_fetch_assoc($sql_settings);
 
 $config_enable_cron      = intval($row['config_enable_cron']);
 
@@ -307,7 +307,7 @@ function sendQueueEmail(
 $sql_queue = mysqli_query($mysqli, "SELECT * FROM email_queue WHERE email_status = 0 AND email_queued_at <= NOW()");
 
 if (mysqli_num_rows($sql_queue) > 0) {
-    while ($rowq = mysqli_fetch_array($sql_queue)) {
+    while ($rowq = mysqli_fetch_assoc($sql_queue)) {
         $email_id             = (int)$rowq['email_id'];
         $email_from           = $rowq['email_from'];
         $email_from_name      = $rowq['email_from_name'];
@@ -401,7 +401,7 @@ $sql_failed_queue = mysqli_query(
 );
 
 if (mysqli_num_rows($sql_failed_queue) > 0) {
-    while ($rowf = mysqli_fetch_array($sql_failed_queue)) {
+    while ($rowf = mysqli_fetch_assoc($sql_failed_queue)) {
         $email_id             = (int)$rowf['email_id'];
         $email_from           = $rowf['email_from'];
         $email_from_name      = $rowf['email_from_name'];

--- a/cron/ticket_email_parser.php
+++ b/cron/ticket_email_parser.php
@@ -34,7 +34,7 @@ $config_ticket_email_parse_unknown_senders = intval($row['config_ticket_email_pa
 
 // Get company name & phone & timezone
 $sql = mysqli_query($mysqli, "SELECT * FROM companies, settings WHERE companies.company_id = settings.company_id AND companies.company_id = 1");
-$row = mysqli_fetch_assoc($sql);
+$row = mysqli_fetch_array($sql);
 $company_name = sanitizeInput($row['company_name']);
 $company_phone = sanitizeInput(formatPhoneNumber($row['company_phone'], $row['company_phone_country_code']));
 
@@ -68,7 +68,7 @@ register_shutdown_function(function() use ($lock_file_path) {
 });
 
 // Allowed attachment extensions
-$allowed_extensions = array('jpg', 'jpeg', 'gif', 'png', 'webp', 'svg', 'pdf', 'txt', 'md', 'doc', 'docx', 'csv', 'xls', 'xlsx', 'xlsm', 'zip', 'tar', 'gz');
+$allowed_extensions = array('jpg', 'jpeg', 'gif', 'png', 'webp', 'pdf', 'txt', 'md', 'doc', 'docx', 'csv', 'xls', 'xlsx', 'xlsm', 'zip', 'tar', 'gz');
 
 /** ------------------------------------------------------------------
  * Ticket / Reply helpers (unchanged)
@@ -106,7 +106,7 @@ function addTicket($contact_id, $contact_name, $contact_email, $client_id, $date
     $contact_email_esc = mysqli_real_escape_string($mysqli, $contact_email);
     $client_id = intval($client_id);
 
-    $url_key = randomString(32);
+    $url_key = randomString(156);
 
     mysqli_query($mysqli, "INSERT INTO tickets SET ticket_prefix = '$ticket_prefix_esc', ticket_number = $ticket_number, ticket_source = 'Email', ticket_subject = '$subject', ticket_details = '$message_esc', ticket_priority = 'Low', ticket_status = 1, ticket_billable = $config_ticket_default_billable, ticket_created_by = 0, ticket_contact_id = $contact_id, ticket_url_key = '$url_key', ticket_client_id = $client_id");
     $id = mysqli_insert_id($mysqli);
@@ -150,10 +150,8 @@ function addTicket($contact_id, $contact_name, $contact_email, $client_id, $date
         mysqli_query($mysqli, "INSERT INTO ticket_watchers SET watcher_email = '$contact_email_esc', watcher_ticket_id = $id");
     }
 
-    // External email
-    $bad_pattern = "/do[\W_]*not[\W_]*reply|no[\W_]*reply/i";
     $data = [];
-    if ($config_ticket_client_general_notifications == 1 && !preg_match($bad_pattern, $contact_email)) {
+    if ($config_ticket_client_general_notifications == 1) {
         $subject_email = "Ticket created - [$config_ticket_prefix$ticket_number] - $subject";
         $body = "<i style='color: #808080'>##- Please type your reply above this line -##</i><br><br>Hello $contact_name,<br><br>Thank you for your email. A ticket regarding \"$subject\" has been automatically created for you.<br><br>Ticket: $config_ticket_prefix$ticket_number<br>Subject: $subject<br>Status: New<br>Portal: <a href='https://$config_base_url/guest/guest_view_ticket.php?ticket_id=$id&url_key=$url_key'>View ticket</a><br><br>--<br>$company_name - Support<br>$config_ticket_from_email<br>$company_phone";
         $data[] = [
@@ -166,19 +164,16 @@ function addTicket($contact_id, $contact_name, $contact_email, $client_id, $date
         ];
     }
 
-    // Internal email
     if ($config_ticket_new_ticket_notification_email) {
         if ($client_id == 0) {
             $client_name = "Guest";
-            $client_uri = '';
         } else {
             $client_sql = mysqli_query($mysqli, "SELECT client_name FROM clients WHERE client_id = $client_id");
-            $client_row = mysqli_fetch_assoc($client_sql);
+            $client_row = mysqli_fetch_array($client_sql);
             $client_name = sanitizeInput($client_row['client_name']);
-            $client_uri = "&client_id=$client_id";
         }
         $email_subject = "$config_app_name - New Ticket - $client_name: $subject";
-        $email_body = "Hello, <br><br>This is a notification that a new ticket has been raised in ITFlow. <br>Client: $client_name<br>Priority: Low (email parsed)<br>Link: https://$config_base_url/agent/ticket.php?ticket_id=$id$client_uri <br><br>--------------------------------<br><br><b>$subject</b><br>$message";
+        $email_body = "Hello, <br><br>This is a notification that a new ticket has been raised in ITFlow. <br>Client: $client_name<br>Priority: Low (email parsed)<br>Link: https://$config_base_url/agent/ticket.php?ticket_id=$id <br><br>--------------------------------<br><br><b>$subject</b><br>$message";
 
         $data[] = [
             'from' => $config_ticket_from_email,
@@ -229,13 +224,14 @@ function addReply($from_email, $date, $subject, $ticket_number, $message, $attac
     $message = nl2br($message);
 
     // 3) Final wrapper
-    $message = "<i>Email from: $from_email at $date:-</i><br><br><div style='line-height:1.5;'>$message</div>";
+    $message = "<i>Email from: $from_email at $date:-</i><br><br>
+    <div style='line-height:1.5;'>$message</div>";
 
     $ticket_number_esc = intval($ticket_number);
     $message_esc = mysqli_real_escape_string($mysqli, $message);
     $from_email_esc = mysqli_real_escape_string($mysqli, $from_email);
 
-    $row = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT ticket_id, ticket_subject, ticket_status, ticket_contact_id, ticket_client_id, contact_email, client_name
+    $row = mysqli_fetch_array(mysqli_query($mysqli, "SELECT ticket_id, ticket_subject, ticket_status, ticket_contact_id, ticket_client_id, contact_email, client_name
         FROM tickets
         LEFT JOIN contacts on tickets.ticket_contact_id = contacts.contact_id
         LEFT JOIN clients on tickets.ticket_client_id = clients.client_id
@@ -248,18 +244,13 @@ function addReply($from_email, $date, $subject, $ticket_number, $message, $attac
         $ticket_reply_contact = intval($row['ticket_contact_id']);
         $ticket_contact_email = sanitizeInput($row['contact_email']);
         $client_id = intval($row['ticket_client_id']);
-        if ($client_id) {
-            $client_uri = "&client_id=$client_id";
-        } else {
-            $client_uri = '';
-        }
         $client_name = sanitizeInput($row['client_name']);
 
         if ($ticket_status == 5) {
             $config_ticket_prefix_esc = mysqli_real_escape_string($mysqli, $config_ticket_prefix);
             $ticket_number_esc2 = mysqli_real_escape_string($mysqli, $ticket_number);
 
-            appNotify("Ticket", "Email parser: $from_email attempted to re-open ticket $config_ticket_prefix_esc$ticket_number_esc2 (ID $ticket_id) - check inbox manually to see email", "/agent/ticket.php?ticket_id=$ticket_id$client_uri", $client_id);
+            appNotify("Ticket", "Email parser: $from_email attempted to re-open ticket $config_ticket_prefix_esc$ticket_number_esc2 (ID $ticket_id) - check inbox manually to see email", "/agent/ticket.php?ticket_id=$ticket_id", $client_id);
 
             $email_subject = "Action required: This ticket is already closed";
             $email_body = "Hi there, <br><br>You've tried to reply to a ticket that is closed - we won't see your response. <br><br>Please raise a new ticket by sending a new e-mail to our support address below. <br><br>--<br>$company_name - Support<br>$config_ticket_from_email<br>$company_phone";
@@ -281,7 +272,7 @@ function addReply($from_email, $date, $subject, $ticket_number, $message, $attac
 
         if (empty($ticket_contact_email) || $ticket_contact_email !== $from_email) {
             $from_email_esc2 = mysqli_real_escape_string($mysqli, $from_email);
-            $row2 = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT contact_id FROM contacts WHERE contact_email = '$from_email_esc2' AND contact_client_id = $client_id LIMIT 1"));
+            $row2 = mysqli_fetch_array(mysqli_query($mysqli, "SELECT contact_id FROM contacts WHERE contact_email = '$from_email_esc2' AND contact_client_id = $client_id LIMIT 1"));
             if ($row2) {
                 $ticket_reply_contact = intval($row2['contact_id']);
             } else {
@@ -321,17 +312,17 @@ function addReply($from_email, $date, $subject, $ticket_number, $message, $attac
 
         $ticket_assigned_to_sql = mysqli_query($mysqli, "SELECT ticket_assigned_to FROM tickets WHERE ticket_id = $ticket_id LIMIT 1");
         if ($ticket_assigned_to_sql) {
-            $row3 = mysqli_fetch_assoc($ticket_assigned_to_sql);
+            $row3 = mysqli_fetch_array($ticket_assigned_to_sql);
             $ticket_assigned_to = intval($row3['ticket_assigned_to']);
 
             if ($ticket_assigned_to) {
                 $tech_sql = mysqli_query($mysqli, "SELECT user_email, user_name FROM users WHERE user_id = $ticket_assigned_to LIMIT 1");
-                $tech_row = mysqli_fetch_assoc($tech_sql);
+                $tech_row = mysqli_fetch_array($tech_sql);
                 $tech_email = sanitizeInput($tech_row['user_email']);
                 $tech_name = sanitizeInput($tech_row['user_name']);
 
                 $email_subject = "$config_app_name - Ticket updated - [$config_ticket_prefix$ticket_number] $ticket_subject";
-                $email_body    = "Hello $tech_name,<br><br>A new reply has been added to the below ticket.<br><br>Client: $client_name<br>Ticket: $config_ticket_prefix$ticket_number<br>Subject: $ticket_subject<br>Link: https://$config_base_url/agent/ticket.php?ticket_id=$ticket_id$client_uri<br><br>--------------------------------<br>$message_esc";
+                $email_body    = "Hello $tech_name,<br><br>A new reply has been added to the below ticket.<br><br>Client: $client_name<br>Ticket: $config_ticket_prefix$ticket_number<br>Subject: $ticket_subject<br>Link: https://$config_base_url/agent/ticket.php?ticket_id=$ticket_id<br><br>--------------------------------<br>$message_esc";
 
                 $data = [
                     [
@@ -620,16 +611,7 @@ foreach ($messages as $message) {
     // Body (prefer HTML)
     $message_body_html = $message->getHTMLBody();
     $message_body_text = $message->getTextBody();
-    $message_body_raw  = $message->getRawBody();
-
-    if (!empty($message_body_html)) {
-        $message_body = $message_body_html;
-    } elseif (!empty($message_body_text)) {
-        $message_body = nl2br(htmlspecialchars($message_body_text));
-    } else {
-        // Final fallback
-        $message_body = nl2br(htmlspecialchars($message_body_raw));
-    }
+    $message_body = $message_body_html ?: nl2br(htmlspecialchars((string)$message_body_text));
 
     // Handle attachments (inline vs regular)
     $attachments = [];
@@ -668,7 +650,7 @@ foreach ($messages as $message) {
         // First: check if sender is a registered contact
         $from_email_esc = mysqli_real_escape_string($mysqli, $from_email);
         $contact_sql = mysqli_query($mysqli, "SELECT * FROM contacts WHERE contact_email = '$from_email_esc' AND contact_archived_at IS NULL LIMIT 1");
-        $contact_row = mysqli_fetch_assoc($contact_sql);
+        $contact_row = mysqli_fetch_array($contact_sql);
 
         if ($contact_row) {
             $contact_id = intval($contact_row['contact_id']);
@@ -713,7 +695,7 @@ foreach ($messages as $message) {
     if (!$email_processed) {
         $from_email_esc = mysqli_real_escape_string($mysqli, $from_email);
         $any_contact_sql = mysqli_query($mysqli, "SELECT * FROM contacts WHERE contact_email = '$from_email_esc' AND contact_archived_at IS NULL LIMIT 1");
-        $rowc = mysqli_fetch_assoc($any_contact_sql);
+        $rowc = mysqli_fetch_array($any_contact_sql);
 
         if ($rowc) {
             $contact_name  = sanitizeInput($rowc['contact_name']);
@@ -749,103 +731,9 @@ foreach ($messages as $message) {
 
     // 5. Unknown sender allowed?
     if (!$email_processed && $config_ticket_email_parse_unknown_senders) {
-
-        $bad_from_pattern = "/daemon|postmaster|bounce|mta/i"; //  Stop NDRs with bad subjects raising new tickets
+        $bad_from_pattern = "/daemon|postmaster/i";
         if (!preg_match($bad_from_pattern, $from_email)) {
             $email_processed = addTicket(0, $from_name, $from_email, 0, $date, $subject, $message_body, $attachments, $original_message_file);
-
-        } else {
-
-            // Probably an NDR message without a ticket ref in the subject
-
-            $failed_recipient  = null;
-            $diagnostic_code   = null;
-            $status_code       = null;
-            $original_subject  = null;
-            $original_to       = null;
-
-            // Webklex stores DSN info in attachments, not parts
-            foreach ($message->getAttachments() as $attachment) {
-
-                $ctype = strtolower($attachment->getContentType());
-                $body  = $attachment->getContent() ?? '';
-
-                // 1. Delivery status block
-                if (strpos($ctype, 'delivery-status') !== false) {
-
-                    if (preg_match('/Final-Recipient:\s*rfc822;\s*(.+)/i', $body, $m)) {
-                        $failed_recipient = sanitizeInput(trim($m[1]));
-                    }
-
-                    if (preg_match('/Diagnostic-Code:\s*(.+)/i', $body, $m)) {
-                        $diagnostic_code = sanitizeInput(trim($m[1]));
-                    }
-
-                    if (preg_match('/Status:\s*([0-9\.]+)/i', $body, $m)) {
-                        $status_code = sanitizeInput(trim($m[1]));
-                    }
-                }
-
-                // 2. Original message headers
-                if (strpos($ctype, 'message/rfc822') !== false) {
-
-                    if (preg_match('/^To:\s*(.+)$/mi', $body, $m)) {
-                        $original_to = sanitizeInput(trim($m[1]));
-                    }
-
-                    if (preg_match('/^Subject:\s*(.+)$/mi', $body, $m)) {
-                        $original_subject = sanitizeInput(trim($m[1]));
-                    }
-                }
-            }
-
-            // 3. Fallback: extract diagnostic from human-readable text/plain
-            if (!$diagnostic_code) {
-                $text = $message->getTextBody() ?? '';
-
-                // Exim puts diagnostics on an indented line
-                if (preg_match('/\n\s{2,}(.+)/', $text, $m)) {
-                    $diagnostic_code = sanitizeInput(trim($m[1]));
-                }
-            }
-
-            // Fallbacks
-            $failed_recipient = $failed_recipient ?: 'unknown recipient';
-            $diagnostic_code  = $diagnostic_code ?: 'unknown diagnostic code';
-            $status_code      = $status_code ?: 'unknown status code';
-            $original_subject = $original_subject ?: $subject;
-
-            appNotify(
-                "Ticket",
-                "Email parser NDR: Message to $failed_recipient bounced. Subject: $original_subject Diagnostics: $status_code / $diagnostic_code - check ITFlow folder manually to see email",
-                "",
-                0
-            );
-
-            // If the original subject has a ticket, add the NDR there too
-            if (preg_match("/\[$config_ticket_prefix(\d+)\]/", $original_subject, $ticket_number_matches)) {
-
-                $ticket_number = intval($ticket_number_matches[1]);
-
-                // Craft a clean bounce message
-                $reply_body = "Email delivery failed.\n".
-                    "Recipient: $failed_recipient\n".
-                    "Status: $status_code\n".
-                    "Diagnostic: $diagnostic_code\n";
-
-                // No attachments
-                addReply(
-                    $from_email,
-                    $date,
-                    $original_subject,
-                    $ticket_number,
-                    $reply_body,
-                    []
-                );
-
-            }
-
-            $email_processed = true;
         }
     }
 
@@ -862,7 +750,9 @@ foreach ($messages as $message) {
             // >>> Put the extra logging RIGHT HERE
             $subj = (string)$message->getSubject();
             $uid  = method_exists($message, 'getUid') ? $message->getUid() : 'n/a';
-            $path = property_exists($targetFolder, 'path') ? $targetFolder->path : 'ITFlow';
+            $path = (is_object($targetFolder) && property_exists($targetFolder, 'path'))
+				? (string)$targetFolder->path
+				: $targetFolderPath;
             logApp(
                 "Cron-Email-Parser",
                 "warning",
@@ -910,5 +800,5 @@ echo "\nLock File Path: $lock_file_path\n";
 if (file_exists($lock_file_path)) {
     echo "\nLock is present\n\n";
 }
-echo "Processed Emails: $processed_count\n";
+echo "Processed Emails into tickets: $processed_count\n";
 echo "Unprocessed Emails: $unprocessed_count\n";


### PR DESCRIPTION
## Overview

This PR improves (or actually, finishes) Microsoft 365 OAuth mail support in ITFlow by adding an in-app web authorization flow and fixing OAuth-related mail gating issues that prevented some emails from being queued/sent.

## What Changed

### 1) New web-based Microsoft OAuth connect flow
- Added a one-click **Connect Microsoft 365** action in **Admin > Settings > Mail**.
- Added a callback endpoint to complete Authorization Code flow and store:
  - `config_mail_oauth_refresh_token`
  - `config_mail_oauth_access_token`
  - `config_mail_oauth_access_token_expires_at`
- Added state validation and expiry checks for callback security.
- Auto-sets IMAP/SMTP providers to `microsoft_oauth` on successful connect.

### 2) OAuth token refresh test in UI
- Added **Test OAuth Token Refresh** action in Mail settings.
- Performs token refresh against provider endpoint and persists updated token/expiry.
- Displays success/failure via existing flash alert flow.

### 3) Mail queue OAuth reliability
- Updated `cron/mail_queue.php` to refresh expired OAuth access tokens and persist refreshed tokens.
- Enables robust SMTP XOAUTH2 sending without manual token maintenance.

### 4) IMAP test supports OAuth auth flow
- Updated IMAP test handler to support OAuth token refresh + XOAUTH2 auth path (not only LOGIN user/pass).

### 5) Ticket reply queueing fix for OAuth SMTP
- Fixed logic in `agent/post/ticket.php` where email queueing was blocked by `config_smtp_host` checks.
- OAuth setups often do not populate SMTP host in settings UI; now checks also allow configured SMTP provider.
- This restores queueing for **Public Comment & Email** and other ticket notification flows under OAuth.

## Bug Fixes Included

- Fixed crash in parser move logging path by guarding `property_exists()` calls against null target folder objects.
- Corrected multiple mail-enabled condition checks to support OAuth provider-based configs.

## Setup Guide (Microsoft 365 OAuth)

1. In Entra App Registration:
   - Add Redirect URI:
     - `https://<your-itflow-domain>/admin/oauth_microsoft_mail_callback.php`
   - Ensure delegated permissions include:
     - `offline_access`
     - `openid`
     - `profile`
     - `https://outlook.office.com/IMAP.AccessAsUser.All`
     - `https://outlook.office.com/SMTP.Send`
   - Grant admin consent.

2. In ITFlow (Admin > Settings > Mail):
   - Set IMAP/SMTP provider to `Microsoft 365 (OAuth)`.
   - Enter Client ID / Client Secret / Tenant ID and mailbox username.
   - Click **Connect Microsoft 365** and complete consent.

3. Validation:
   - Run **Test OAuth Token Refresh**
   - Run **Test IMAP Connection**
   - Run **Test Email Sending**
   - Run cron scripts with PHP >= 8.2 to ensure there are no errors shown:
     - `cron/mail_queue.php`
     - `cron/ticket_email_parser.php`

## Notes

- No tenant/client secrets or refresh tokens are hard-coded in source.
- Callback URI is generated from install base URL config.

## Works for Google OAuth too:

`mail_queue.php` - token refresh/send logic supports both 'google_oauth' and 'microsoft_oauth'.
IMAP OAuth test path in `settings_mail.php` supports both providers.

Not implemented for Google in this PR:
The new web “Connect Microsoft 365” button/callback flow is Microsoft-only.
 This is simply because there is no equivalent “Connect Google” web callback endpoint yet.

So Google can work with manual OAuth fields (especially refresh token), but the one-click web onboarding is currently Microsoft-only